### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: New Release
+permissions:
+  contents: write
 
 on:
   milestone:


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/xml2doc/security/code-scanning/4](https://github.com/mod-posh/xml2doc/security/code-scanning/4)

To fix the problem, explicitly declare a `permissions:` block at the top level of the workflow (recommended) or for the affected job. This ensures that only the necessary permissions are granted to the workflow's `GITHUB_TOKEN`, reducing security risks. 

Given that this workflow pushes to branches, creates releases, and interacts with repository content, at minimum it requires `contents: write`, and possibly also `pull-requests: write` or `issues: write` if those operations are performed. However, based on the workflow shown, `contents: write` is required for pushing documentation and creating releases. To adhere to the principle of least privilege, set:

```yaml
permissions:
  contents: write
```

Add this block immediately after the `name:` field and before `on:` in `.github/workflows/release.yml`. No other changes or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
