### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and Package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/xml2doc/security/code-scanning/3](https://github.com/mod-posh/xml2doc/security/code-scanning/3)

The best way to fix the issue is to explicitly add a `permissions` block that restricts the workflow's access to the minimum required by its steps. Since the workflow just checks out code (`actions/checkout`), reads a project file, builds/packages the code, and pushes to NuGet using a secret API key (not needing GITHUB_TOKEN write access), it only needs read access to repository contents. Place a block at the workflow (top/root) level so it applies to all jobs. Concretely, add:

```yaml
permissions:
  contents: read
```

after the `name:` and before the `on:` block in `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
