### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -1,5 +1,8 @@
 name: Announce New Release
 
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: ["New Release"]  # Make sure this matches `release.yml`


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/xml2doc/security/code-scanning/2](https://github.com/mod-posh/xml2doc/security/code-scanning/2)

To fix this, add a `permissions` key explicitly defining the least privilege permissions needed for this workflow. For this workflow’s tasks (listing releases and posting to external webhooks), minimal GitHub token permissions are required. The only required permission is `contents: read` to allow the `gh release list` to function. This should be set at either the workflow root level (applying to all jobs) or on the job itself. The most future-proof and clear fix is to add the following at the top level (after `name:` and before/after `on:`) so it applies to all jobs unless otherwise specified:

```yaml
permissions:
  contents: read
```

No other changes to steps, jobs, or secrets are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
