### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Merge Test Workflow
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/xml2doc/security/code-scanning/1](https://github.com/mod-posh/xml2doc/security/code-scanning/1)

To fix this problem, we need to add a `permissions` block limiting the workflow's access to the least necessary. Since the workflow only requires reading the contents of the repository (for `actions/checkout`), and no steps involve writing pull requests, issues, etc., we can safely restrict permissions to `contents: read`. The best practice is to place the `permissions` block at the workflow root (top level), just after the `name:` and before `on:`, so it applies to all jobs in the workflow unless individually overridden. No other methods, imports, or code definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
