### PR TITLE
Accept ADR-011 generated output ownership

### DIFF
--- a/docs/adr/ADR-011-generated-output-ownership.md
+++ b/docs/adr/ADR-011-generated-output-ownership.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,4 +18,4 @@ These records explain **why architectural decisions were made**.
 | ADR‑008 | Multi‑target compatibility     | Accepted |
 | ADR‑009 | Structured diagnostics         | Proposed |
 | ADR‑010 | Pluggable anchor algorithms    | Proposed |
-| ADR‑011 | Generated output ownership     | Proposed |
+| ADR‑011 | Generated output ownership     | Accepted |


### PR DESCRIPTION
## Summary

- Marks ADR-011 as Accepted following the merge of #65
- Updates the ADR index to reflect the accepted status

## Scope

Documentation-only governance reconciliation. Issue #64 implementation remains separate.