### PR TITLE
Add deterministic Markdown line endings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,16 +37,16 @@ jobs:
           global-json-file: ./global.json
 
       - name: Clean
-        run: dotnet clean ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --configuration Release --disable-build-servers
+        run: dotnet clean ${{ github.workspace }}/Xml2Doc/Xml2Doc.sln --configuration Release --disable-build-servers
 
       - name: Restore dependencies
-        run: dotnet restore ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --disable-build-servers
+        run: dotnet restore ${{ github.workspace }}/Xml2Doc/Xml2Doc.sln --disable-build-servers
 
       - name: Build
-        run: dotnet build ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --configuration Release --no-restore --disable-build-servers
+        run: dotnet build ${{ github.workspace }}/Xml2Doc/Xml2Doc.sln --configuration Release --no-restore --disable-build-servers
 
       - name: Test (exclude integration)
-        run: dotnet test ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --configuration Release --no-build --logger "trx;LogFileName=test_results.trx" --filter "Category!=Integration"
+        run: dotnet test ${{ github.workspace }}/Xml2Doc/Xml2Doc.sln --configuration Release --no-build --logger "trx;LogFileName=test_results.trx" --filter "Category!=Integration"
 
       - name: Publish Test Results
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,11 @@ on:
 
 jobs:
   run_tests:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
@@ -48,5 +52,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: Test Results
+          name: Test Results (${{ matrix.os }})
           path: '**/TestResults/*.trx'

--- a/Xml2Doc/src/Xml2Doc.Cli/Config.cs
+++ b/Xml2Doc/src/Xml2Doc.Cli/Config.cs
@@ -88,5 +88,8 @@ namespace Xml2Doc.Cli
 
         /// <summary>Stable invocation identity used to scope output ownership. Maps to <c>--manifest-id</c>.</summary>
         public string? ManifestIdentity { get; set; }
+
+        /// <summary>Markdown line endings (<c>lf</c>, <c>crlf</c>, or <c>native</c>). Maps to <c>--line-endings</c>.</summary>
+        public string? LineEndings { get; set; }
     }
 }

--- a/Xml2Doc/src/Xml2Doc.Cli/README.md
+++ b/Xml2Doc/src/Xml2Doc.Cli/README.md
@@ -56,6 +56,7 @@ Xml2Doc.exe --xml .\bin\Release\net9.0\MyLib.xml --out .\docs\api.md --single --
 | `--config <file>`                | Path to a JSON configuration file                             |
 | `--prune-stale`                 | Remove stale files previously owned by this invocation        |
 | `--manifest-id <identity>`      | Stable ownership identity required with `--prune-stale`       |
+| `--line-endings <style>`       | Markdown newlines: `lf` (default), `crlf`, or `native`         |
 | `--help`                         | Display help text                                             |
 
 ### Example Config File
@@ -90,6 +91,11 @@ Xml2Doc.exe --config xml2doc.json
 ```
 
 CLI flags always override values from the config file.
+
+Generated Markdown uses LF on every platform by default. Use `--line-endings crlf` only when a
+consumer requires CRLF, or `--line-endings native` for host-specific compatibility. A
+`.gitattributes` rule such as `*.md text eol=lf` can reinforce repository policy, but is not required
+for deterministic Xml2Doc output.
 
 ## Notes for CI
 

--- a/Xml2Doc/src/Xml2Doc.Cli/xml2doc.cs
+++ b/Xml2Doc/src/Xml2Doc.Cli/xml2doc.cs
@@ -92,6 +92,8 @@ namespace Xml2Doc.Cli
             string? configPath = null;
             bool pruneStaleFiles = false;
             string? manifestIdentity = null;
+            string lineEndings = "lf";
+            bool lineEndingsSpecified = false;
 
             // Parse CLI
             for (int i = 0; i < args.Length; i++)
@@ -127,6 +129,10 @@ namespace Xml2Doc.Cli
                     case "--config" when i + 1 < args.Length: configPath = args[++i]; break;
                     case "--prune-stale": pruneStaleFiles = true; break;
                     case "--manifest-id" when i + 1 < args.Length: manifestIdentity = args[++i]; break;
+                    case "--line-endings" when i + 1 < args.Length:
+                        lineEndings = args[++i];
+                        lineEndingsSpecified = true;
+                        break;
                     case "--help":
                     case "-h":
                         PrintHelp();
@@ -169,6 +175,11 @@ namespace Xml2Doc.Cli
                 if (cfg?.PruneStaleFiles is bool ps) pruneStaleFiles = ps || pruneStaleFiles;
                 if (!string.IsNullOrWhiteSpace(cfg?.ManifestIdentity))
                     manifestIdentity ??= cfg.ManifestIdentity;
+                if (!lineEndingsSpecified &&
+                    !string.IsNullOrWhiteSpace(cfg?.LineEndings))
+                {
+                    lineEndings = cfg.LineEndings!;
+                }
             }
 
             if (string.IsNullOrWhiteSpace(xml) || string.IsNullOrWhiteSpace(outArg))
@@ -188,6 +199,25 @@ namespace Xml2Doc.Cli
             {
                 Console.Error.WriteLine("--manifest-id is required when --prune-stale is enabled.");
                 return 1;
+            }
+
+            LineEndingStyle lineEndingStyle;
+
+            switch (lineEndings.ToLowerInvariant())
+            {
+                case "lf":
+                    lineEndingStyle = LineEndingStyle.Lf;
+                    break;
+                case "crlf":
+                    lineEndingStyle = LineEndingStyle.CrLf;
+                    break;
+                case "native":
+                    lineEndingStyle = LineEndingStyle.Native;
+                    break;
+                default:
+                    Console.Error.WriteLine(
+                        "--line-endings must be one of: lf, crlf, native.");
+                    return 1;
             }
 
             // Anchor algorithm token → enum
@@ -220,7 +250,8 @@ namespace Xml2Doc.Cli
                     ParallelDegree: parallel,
                     GenerateIndex: generateIndex,
                     PruneStaleFiles: pruneStaleFiles,
-                    ManifestIdentity: manifestIdentity
+                    ManifestIdentity: manifestIdentity,
+                    LineEndings: lineEndingStyle
                 );
 
                 var renderer = new MarkdownRenderer(model, options);
@@ -311,7 +342,8 @@ namespace Xml2Doc.Cli
                             basenameOnly = options.BasenameOnly,
                             parallel,
                             pruneStaleFiles,
-                            manifestIdentity
+                            manifestIdentity,
+                            lineEndings = lineEndingStyle.ToString()
                         },
                         dryRun,
                         diffRequested = diff,
@@ -365,6 +397,7 @@ namespace Xml2Doc.Cli
             Console.WriteLine("                   [--basename-only]");
             Console.WriteLine("                   [--parallel <N>]");
             Console.WriteLine("                   [--prune-stale --manifest-id <identity>]");
+            Console.WriteLine("                   [--line-endings <lf|crlf|native>]");
             Console.WriteLine("                   [--config <file>]");
             Console.WriteLine();
         }

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -272,7 +272,7 @@ public sealed class MarkdownRenderer
         var outputRoot = Path.GetFullPath(outputDirectory)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
             Path.DirectorySeparatorChar;
-        var candidate = Path.GetFullPath(Path.Combine(outputRoot, fileName));
+        var candidate = Path.GetFullPath(outputRoot + fileName);
         var comparison = Path.DirectorySeparatorChar == '\\'
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -269,7 +269,18 @@ public sealed class MarkdownRenderer
         if (Path.IsPathRooted(fileName))
             throw new ArgumentException("The output file name must be relative.", nameof(fileName));
 
-        return Path.Combine(outputDirectory, fileName);
+        var outputRoot = Path.GetFullPath(outputDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+            Path.DirectorySeparatorChar;
+        var candidate = Path.GetFullPath(Path.Combine(outputRoot, fileName));
+        var comparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        if (!candidate.StartsWith(outputRoot, comparison))
+            throw new ArgumentException("The output file name must remain within the output directory.", nameof(fileName));
+
+        return candidate;
     }
 
     /// <summary>

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -150,7 +150,7 @@ public sealed class MarkdownRenderer
             }
             if (_opt.GenerateIndex)
                 File.WriteAllText(
-                    Path.Combine(outDir, "index.md"),
+                    outDir + Path.DirectorySeparatorChar + "index.md",
                     NormalizeLineEndings(RenderIndex(types, useAnchors: false)),
                     MarkdownEncoding);
 
@@ -196,7 +196,7 @@ public sealed class MarkdownRenderer
                     nsIndex.AppendLine($"- [{ns}](namespaces/{fileSafe}.md)");
                 }
                 File.WriteAllText(
-                    Path.Combine(outDir, "namespaces.md"),
+                    outDir + Path.DirectorySeparatorChar + "namespaces.md",
                     NormalizeLineEndings(nsIndex.ToString()),
                     MarkdownEncoding);
             }

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -41,6 +41,8 @@ namespace Xml2Doc.Core;
 /// </remarks>
 public sealed class MarkdownRenderer
 {
+    private static readonly Encoding MarkdownEncoding =
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
     private readonly Models.Xml2Doc _model;
     private readonly RendererOptions _opt;
 
@@ -141,10 +143,16 @@ public sealed class MarkdownRenderer
             foreach (var t in types)
             {
                 var file = Path.Combine(outDir, FileNameForPerType(t.Id));
-                File.WriteAllText(file, RenderType(t, includeHeader: true));
+                File.WriteAllText(
+                    file,
+                    NormalizeLineEndings(RenderType(t, includeHeader: true)),
+                    MarkdownEncoding);
             }
             if (_opt.GenerateIndex)
-                File.WriteAllText(Path.Combine(outDir, "index.md"), RenderIndex(types, useAnchors: false));
+                File.WriteAllText(
+                    Path.Combine(outDir, "index.md"),
+                    NormalizeLineEndings(RenderIndex(types, useAnchors: false)),
+                    MarkdownEncoding);
 
             if (_opt.EmitNamespaceIndex)
             {
@@ -174,7 +182,10 @@ public sealed class MarkdownRenderer
                         var perTypeFile = FileNameForPerType(t.Id);
                         sbNs.AppendLine($"- [{shortName}]({Path.Combine("..", perTypeFile).Replace('\\', '/')})");
                     }
-                    File.WriteAllText(nsFile, sbNs.ToString());
+                    File.WriteAllText(
+                        nsFile,
+                        NormalizeLineEndings(sbNs.ToString()),
+                        MarkdownEncoding);
                 }
 
                 var nsIndex = new StringBuilder();
@@ -184,7 +195,10 @@ public sealed class MarkdownRenderer
                     var fileSafe = ns == "(global)" ? "_global_" : SafeNamespaceFileName(ns);
                     nsIndex.AppendLine($"- [{ns}](namespaces/{fileSafe}.md)");
                 }
-                File.WriteAllText(Path.Combine(outDir, "namespaces.md"), nsIndex.ToString());
+                File.WriteAllText(
+                    Path.Combine(outDir, "namespaces.md"),
+                    NormalizeLineEndings(nsIndex.ToString()),
+                    MarkdownEncoding);
             }
 
             if (manifestLocation is not null &&
@@ -215,7 +229,10 @@ public sealed class MarkdownRenderer
         {
             _singleFileMode = true;
             Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
-            File.WriteAllText(outPath, BuildSingleFileContent());
+            File.WriteAllText(
+                outPath,
+                NormalizeLineEndings(BuildSingleFileContent()),
+                MarkdownEncoding);
         }
         finally
         {
@@ -226,7 +243,26 @@ public sealed class MarkdownRenderer
     /// <summary>
     /// Returns the consolidated single‑file content (index + all types) without writing.
     /// </summary>
-    public string RenderToString() => BuildSingleFileContent();
+    public string RenderToString() =>
+        NormalizeLineEndings(BuildSingleFileContent());
+
+    private string NormalizeLineEndings(string content)
+    {
+        var normalized = content
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n');
+
+        var lineEnding = _opt.LineEndings switch
+        {
+            LineEndingStyle.CrLf => "\r\n",
+            LineEndingStyle.Native => Environment.NewLine,
+            _ => "\n"
+        };
+
+        return lineEnding == "\n"
+            ? normalized
+            : normalized.Replace("\n", lineEnding);
+    }
 
     /// <summary>
     /// Builds single‑file content, temporarily switching link mode to in‑document anchors.

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -150,7 +150,7 @@ public sealed class MarkdownRenderer
             }
             if (_opt.GenerateIndex)
                 File.WriteAllText(
-                    outDir + Path.DirectorySeparatorChar + "index.md",
+                    CombineOutputPath(outDir, "index.md"),
                     NormalizeLineEndings(RenderIndex(types, useAnchors: false)),
                     MarkdownEncoding);
 
@@ -196,7 +196,7 @@ public sealed class MarkdownRenderer
                     nsIndex.AppendLine($"- [{ns}](namespaces/{fileSafe}.md)");
                 }
                 File.WriteAllText(
-                    outDir + Path.DirectorySeparatorChar + "namespaces.md",
+                    CombineOutputPath(outDir, "namespaces.md"),
                     NormalizeLineEndings(nsIndex.ToString()),
                     MarkdownEncoding);
             }
@@ -262,6 +262,14 @@ public sealed class MarkdownRenderer
         return lineEnding == "\n"
             ? normalized
             : normalized.Replace("\n", lineEnding);
+    }
+
+    private static string CombineOutputPath(string outputDirectory, string fileName)
+    {
+        if (Path.IsPathRooted(fileName))
+            throw new ArgumentException("The output file name must be relative.", nameof(fileName));
+
+        return Path.Combine(outputDirectory, fileName);
     }
 
     /// <summary>

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -25,6 +25,7 @@ Now multi-targeted and verified for consistent output across modern .NET TFMs.
   - `RootNamespaceToTrim` (display-only trimming)
   - Code block language (default `csharp`)
   - Per-type `index.md` generation (`GenerateIndex`, default `true`)
+  - Markdown line endings (`Lf` default, `CrLf`, or `Native`)
   - Output mode (single vs. multi-file)
 
 ## Supported Target Frameworks
@@ -35,8 +36,9 @@ Shipped TFMs:
 - `net8.0`
 - `net9.0`
 
-**Guarantee:** Markdown output is deterministic and equivalent across these TFMs.
-We test cross-TFM by rendering with multiple runtimes and asserting identical output (normalized line endings).
+**Guarantee:** Default Markdown output is deterministic and equivalent across these TFMs and hosts,
+including LF line endings. We test cross-TFM output directly without relying on post-render newline
+normalization.
 
 ### Language-version notes
 

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -48,6 +48,21 @@ namespace Xml2Doc.Core
     }
 
     /// <summary>
+    /// Controls the line-ending sequence used in rendered Markdown.
+    /// </summary>
+    public enum LineEndingStyle
+    {
+        /// <summary>Use line feed (<c>\n</c>) on every platform.</summary>
+        Lf = 0,
+
+        /// <summary>Use carriage return followed by line feed (<c>\r\n</c>).</summary>
+        CrLf = 1,
+
+        /// <summary>Use <see cref="Environment.NewLine"/> for the current host.</summary>
+        Native = 2
+    }
+
+    /// <summary>
     /// Rendering options applied when converting XML documentation to Markdown.
     /// </summary>
     /// <param name="FileNameMode">
@@ -105,6 +120,9 @@ namespace Xml2Doc.Core
     /// <param name="ManifestIdentity">
     /// Explicit stable invocation identity required when <paramref name="PruneStaleFiles"/> is true.
     /// </param>
+    /// <param name="LineEndings">
+    /// Line-ending policy for all rendered Markdown. Defaults to deterministic LF on every host.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -149,6 +167,7 @@ namespace Xml2Doc.Core
         int? ParallelDegree = null,
         bool GenerateIndex = true,
         bool PruneStaleFiles = false,
-        string? ManifestIdentity = null
+        string? ManifestIdentity = null,
+        LineEndingStyle LineEndings = LineEndingStyle.Lf
     );
 }

--- a/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
@@ -357,7 +357,7 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
                     lang: options.CodeBlockLanguage ?? "",
                     pruneStaleFiles: PruneStaleFiles,
                     manifestIdentity: ManifestIdentity ?? "",
-                    lineEndings: lineEndingStyle.ToString()
+                    lineEndings: GetLineEndingFingerprintToken(lineEndingStyle)
                 );
             }
 
@@ -476,6 +476,11 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
         foreach (var b in hash) sb.Append(b.ToString("x2"));
         return sb.ToString();
     }
+
+    private static string GetLineEndingFingerprintToken(LineEndingStyle lineEndingStyle) =>
+        lineEndingStyle == LineEndingStyle.Native
+            ? $"Native:{Environment.NewLine.Length}"
+            : lineEndingStyle.ToString();
 
     /// <summary>
     /// Normalizes a path for hashing (full path, trimmed trailing separators). Returns empty string for blank or on failure.

--- a/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
@@ -146,6 +146,11 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
     public string? ManifestIdentity { get; set; }
 
     /// <summary>
+    /// Markdown line endings: <c>lf</c> (default), <c>crlf</c>, or <c>native</c>.
+    /// </summary>
+    public string LineEndings { get; set; } = "lf";
+
+    /// <summary>
     /// When true, uses only the basename for file references (omits directory paths).
     /// </summary>
     public bool BasenameOnly { get; set; }
@@ -232,6 +237,25 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
                 return false;
             }
 
+            LineEndingStyle lineEndingStyle;
+
+            switch ((LineEndings ?? "lf").ToLowerInvariant())
+            {
+                case "lf":
+                    lineEndingStyle = LineEndingStyle.Lf;
+                    break;
+                case "crlf":
+                    lineEndingStyle = LineEndingStyle.CrLf;
+                    break;
+                case "native":
+                    lineEndingStyle = LineEndingStyle.Native;
+                    break;
+                default:
+                    Log.LogError(
+                        "Xml2Doc: LineEndings must be one of: lf, crlf, native.");
+                    return false;
+            }
+
             if (string.IsNullOrWhiteSpace(XmlSha256))
             {
                 try { XmlSha256 = ComputeFileSha256(xmlFull); }
@@ -266,7 +290,8 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
                 AnchorAlgorithm: anchorAlgEnum,
                 GenerateIndex: GenerateIndex,
                 PruneStaleFiles: PruneStaleFiles,
-                ManifestIdentity: ManifestIdentity
+                ManifestIdentity: ManifestIdentity,
+                LineEndings: lineEndingStyle
             );
 
             var renderer = new MarkdownRenderer(model, options);
@@ -331,7 +356,8 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
                     rootNs: options.RootNamespaceToTrim ?? "",
                     lang: options.CodeBlockLanguage ?? "",
                     pruneStaleFiles: PruneStaleFiles,
-                    manifestIdentity: ManifestIdentity ?? ""
+                    manifestIdentity: ManifestIdentity ?? "",
+                    lineEndings: lineEndingStyle.ToString()
                 );
             }
 
@@ -357,7 +383,8 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
                             rootNs = options.RootNamespaceToTrim,
                             lang = options.CodeBlockLanguage,
                             pruneStaleFiles = PruneStaleFiles,
-                            manifestIdentity = ManifestIdentity
+                            manifestIdentity = ManifestIdentity,
+                            lineEndings = lineEndingStyle.ToString()
                         },
                         fingerprint = Fingerprint,
                         xmlSha256 = XmlSha256,
@@ -417,6 +444,7 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
     /// <param name="lang">Code block language identifier.</param>
     /// <param name="pruneStaleFiles">Whether stale-output pruning is enabled.</param>
     /// <param name="manifestIdentity">Stable invocation-scoped ownership identity.</param>
+    /// <param name="lineEndings">Selected Markdown line-ending policy.</param>
     /// <returns>SHA-256 hash of the concatenated input parameters.</returns>
     private static string ComputeFingerprint(
         string xmlSha256,
@@ -426,7 +454,8 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
         string rootNs,
         string lang,
         bool pruneStaleFiles,
-        string manifestIdentity)
+        string manifestIdentity,
+        string lineEndings)
     {
         using var sha = SHA256.Create();
         var data = string.Join("|", new[]
@@ -438,7 +467,8 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
             rootNs,
             lang,
             pruneStaleFiles.ToString(),
-            manifestIdentity
+            manifestIdentity,
+            lineEndings
         });
         var bytes = Encoding.UTF8.GetBytes(data);
         var hash = sha.ComputeHash(bytes);
@@ -517,5 +547,8 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
 
         /// <summary>Stable invocation identity used to scope ownership.</summary>
         public string? manifestIdentity { get; set; }
+
+        /// <summary>Selected Markdown line-ending policy.</summary>
+        public string? lineEndings { get; set; }
     }
 }

--- a/Xml2Doc/src/Xml2Doc.MSBuild/README.md
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/README.md
@@ -51,6 +51,7 @@ That’s it—on successful build, docs are generated according to the propertie
 | `Xml2Doc_CodeBlockLanguage`   | Code block language for fenced blocks (default `csharp`).                  |
 | `Xml2Doc_PruneStaleFiles`     | Remove stale files owned by this invocation. Default: `false`.             |
 | `Xml2Doc_ManifestIdentity`    | Stable identity required when stale-output pruning is enabled.             |
+| `Xml2Doc_LineEndings`         | Markdown newlines: `lf` (default), `crlf`, or `native`.                    |
 
 ### Examples
 
@@ -100,6 +101,20 @@ and create the repository-level index in a separate aggregation step:
 Use an identity that remains stable for the same invocation. Only files recorded by that exact
 identity can be removed; hand-authored files and files owned by other builds are preserved.
 Pruning is supported only for per-type output.
+
+**Line-ending policy**
+
+Generated Markdown uses LF on every platform by default. Consumers that require another policy can
+select it explicitly:
+
+```xml
+<PropertyGroup>
+  <Xml2Doc_LineEndings>crlf</Xml2Doc_LineEndings>
+</PropertyGroup>
+```
+
+Use `native` only for host-specific compatibility. A `.gitattributes` rule such as
+`*.md text eol=lf` can reinforce repository policy but is not required for deterministic output.
 
 **Only generate in Release**
 

--- a/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.props
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.props
@@ -44,6 +44,7 @@
     <Xml2Doc_GenerateIndex Condition="'$(Xml2Doc_GenerateIndex)'==''">true</Xml2Doc_GenerateIndex>
     <Xml2Doc_PruneStaleFiles Condition="'$(Xml2Doc_PruneStaleFiles)'==''">false</Xml2Doc_PruneStaleFiles>
     <Xml2Doc_ManifestIdentity Condition="'$(Xml2Doc_ManifestIdentity)'==''"></Xml2Doc_ManifestIdentity>
+    <Xml2Doc_LineEndings Condition="'$(Xml2Doc_LineEndings)'==''">lf</Xml2Doc_LineEndings>
 
     <Xml2Doc_ReportIncludeTimestamp Condition="'$(Xml2Doc_ReportIncludeTimestamp)'==''">false</Xml2Doc_ReportIncludeTimestamp>
 

--- a/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
@@ -82,7 +82,8 @@
     </GetFileHash>
 
     <PropertyGroup>
-      <_Xml2Doc_Options>$(Xml2Doc_SingleFile)|$(Xml2Doc_OutputFile)|$(Xml2Doc_OutputDir)|$(Xml2Doc_FileNameMode)|$(Xml2Doc_RootNamespaceToTrim)|$(Xml2Doc_CodeBlockLanguage)|$(Xml2Doc_Toc)|$(Xml2Doc_NamespaceIndex)|$(Xml2Doc_BasenameOnly)|$(Xml2Doc_TrimRootNamespaceInFileNames)|$(Xml2Doc_AnchorAlgorithm)|$(Xml2Doc_GenerateIndex)|$(Xml2Doc_PruneStaleFiles)|$(Xml2Doc_ManifestIdentity)|$(Xml2Doc_LineEndings)</_Xml2Doc_Options>
+      <_Xml2Doc_NativeLineEndingToken Condition="'$(Xml2Doc_LineEndings)' == 'native'">native-$([System.Environment]::NewLine.Length)</_Xml2Doc_NativeLineEndingToken>
+      <_Xml2Doc_Options>$(Xml2Doc_SingleFile)|$(Xml2Doc_OutputFile)|$(Xml2Doc_OutputDir)|$(Xml2Doc_FileNameMode)|$(Xml2Doc_RootNamespaceToTrim)|$(Xml2Doc_CodeBlockLanguage)|$(Xml2Doc_Toc)|$(Xml2Doc_NamespaceIndex)|$(Xml2Doc_BasenameOnly)|$(Xml2Doc_TrimRootNamespaceInFileNames)|$(Xml2Doc_AnchorAlgorithm)|$(Xml2Doc_GenerateIndex)|$(Xml2Doc_PruneStaleFiles)|$(Xml2Doc_ManifestIdentity)|$(Xml2Doc_LineEndings)|$(_Xml2Doc_NativeLineEndingToken)</_Xml2Doc_Options>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
@@ -82,7 +82,7 @@
     </GetFileHash>
 
     <PropertyGroup>
-      <_Xml2Doc_Options>$(Xml2Doc_SingleFile)|$(Xml2Doc_OutputFile)|$(Xml2Doc_OutputDir)|$(Xml2Doc_FileNameMode)|$(Xml2Doc_RootNamespaceToTrim)|$(Xml2Doc_CodeBlockLanguage)|$(Xml2Doc_Toc)|$(Xml2Doc_NamespaceIndex)|$(Xml2Doc_BasenameOnly)|$(Xml2Doc_TrimRootNamespaceInFileNames)|$(Xml2Doc_AnchorAlgorithm)|$(Xml2Doc_GenerateIndex)|$(Xml2Doc_PruneStaleFiles)|$(Xml2Doc_ManifestIdentity)</_Xml2Doc_Options>
+      <_Xml2Doc_Options>$(Xml2Doc_SingleFile)|$(Xml2Doc_OutputFile)|$(Xml2Doc_OutputDir)|$(Xml2Doc_FileNameMode)|$(Xml2Doc_RootNamespaceToTrim)|$(Xml2Doc_CodeBlockLanguage)|$(Xml2Doc_Toc)|$(Xml2Doc_NamespaceIndex)|$(Xml2Doc_BasenameOnly)|$(Xml2Doc_TrimRootNamespaceInFileNames)|$(Xml2Doc_AnchorAlgorithm)|$(Xml2Doc_GenerateIndex)|$(Xml2Doc_PruneStaleFiles)|$(Xml2Doc_ManifestIdentity)|$(Xml2Doc_LineEndings)</_Xml2Doc_Options>
     </PropertyGroup>
 
     <ItemGroup>
@@ -145,6 +145,7 @@
                                 GenerateIndex="$(Xml2Doc_GenerateIndex)"
                                 PruneStaleFiles="$(Xml2Doc_PruneStaleFiles)"
                                 ManifestIdentity="$(Xml2Doc_ManifestIdentity)"
+                                LineEndings="$(Xml2Doc_LineEndings)"
                                 BasenameOnly="$(Xml2Doc_BasenameOnly)"
                                 AnchorAlgorithm="$(Xml2Doc_AnchorAlgorithm)"
                                 Fingerprint="$(_Xml2Doc_Fingerprint)"

--- a/Xml2Doc/tests/Xml2Doc.Tests/CliLifecycleTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/CliLifecycleTests.cs
@@ -178,6 +178,81 @@ namespace Xml2Doc.Tests
             wouldDelete.ShouldBe(new[] { output.FullPath("stale.md") });
         }
 
+        [Fact]
+        public void Main_WhenLineEndingsValueIsInvalid_ReturnsValidationFailure()
+        {
+            using var output = TemporaryOutput.Create();
+
+            var exitCode = Program.Main(new[]
+            {
+                "--xml", SampleXml,
+                "--out", output.Path,
+                "--line-endings", "invalid"
+            });
+
+            exitCode.ShouldBe(1);
+            Directory.Exists(output.Path).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Main_WhenCrLfSelected_WritesCrLfMarkdown()
+        {
+            using var output = TemporaryOutput.Create();
+
+            var exitCode = Program.Main(new[]
+            {
+                "--xml", SampleXml,
+                "--out", output.Path,
+                "--line-endings", "crlf"
+            });
+
+            exitCode.ShouldBe(0);
+            var markdown = Directory
+                .GetFiles(output.Path, "*.md")
+                .Select(File.ReadAllText)
+                .First();
+            AssertUsesOnly(markdown, "\r\n");
+        }
+
+        [Fact]
+        public void Main_WhenCliOverridesConfigLineEndings_UsesCliValue()
+        {
+            using var output = TemporaryOutput.Create();
+            var configPath = output.FullPath("xml2doc.json");
+            output.Write(
+                "xml2doc.json",
+                JsonSerializer.Serialize(new CliConfig
+                {
+                    Xml = SampleXml,
+                    Out = output.Path,
+                    LineEndings = "crlf"
+                }));
+
+            var exitCode = Program.Main(new[]
+            {
+                "--config", configPath,
+                "--line-endings", "lf"
+            });
+
+            exitCode.ShouldBe(0);
+            var markdown = Directory
+                .GetFiles(output.Path, "*.md")
+                .Select(File.ReadAllText)
+                .First();
+            markdown.ShouldNotContain("\r");
+        }
+
+        private static void AssertUsesOnly(
+            string content,
+            string expectedLineEnding)
+        {
+            content.ShouldContain(expectedLineEnding);
+            var withoutExpected =
+                content.Replace(expectedLineEnding, string.Empty);
+            withoutExpected.ShouldNotContain("\r");
+            withoutExpected.ShouldNotContain("\n");
+        }
+
         private sealed class TemporaryOutput : IDisposable
         {
             private TemporaryOutput(string path)

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -245,6 +245,10 @@ namespace Xml2Doc.Tests
                 .ShouldBe("$(Xml2Doc_ManifestIdentity)");
             props.Descendants("Xml2Doc_LineEndings")
                 .Single().Value.ShouldBe("lf");
+            targets.Descendants("_Xml2Doc_NativeLineEndingToken")
+                .Single().Value.ShouldContain("Environment]::NewLine.Length");
+            targets.Descendants("_Xml2Doc_Options")
+                .Single().Value.ShouldContain("$(_Xml2Doc_NativeLineEndingToken)");
             taskElement.Attribute("LineEndings")!.Value
                 .ShouldBe("$(Xml2Doc_LineEndings)");
         }

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -217,7 +217,7 @@ namespace Xml2Doc.Tests
         }
 
         [Fact]
-        public void BuildAssets_ExposeAndWirePruningProperties()
+        public void BuildAssets_ExposeAndWireLifecycleProperties()
         {
             var buildDirectory =
                 RepositoryRoot + Path.DirectorySeparatorChar +
@@ -243,6 +243,54 @@ namespace Xml2Doc.Tests
                 .ShouldBe("$(Xml2Doc_PruneStaleFiles)");
             taskElement.Attribute("ManifestIdentity")!.Value
                 .ShouldBe("$(Xml2Doc_ManifestIdentity)");
+            props.Descendants("Xml2Doc_LineEndings")
+                .Single().Value.ShouldBe("lf");
+            taskElement.Attribute("LineEndings")!.Value
+                .ShouldBe("$(Xml2Doc_LineEndings)");
+        }
+
+        [Fact]
+        public void LineEndings_WhenValueIsInvalid_FailsBeforeWriting()
+        {
+            var outDir = CreateOutputDirectory();
+            var task = CreateTask(outDir);
+            task.LineEndings = "invalid";
+
+            task.Execute().ShouldBeFalse();
+
+            task.DidWork.ShouldBeFalse();
+            Directory.Exists(outDir).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void PerType_WhenCrLfSelected_WritesCrLfMarkdown()
+        {
+            var outDir = CreateOutputDirectory();
+
+            try
+            {
+                var task = CreateTask(outDir);
+                task.LineEndings = "crlf";
+
+                task.Execute().ShouldBeTrue();
+
+                var markdown = Directory
+                    .GetFiles(outDir, "*.md")
+                    .Select(File.ReadAllText)
+                    .First();
+                markdown.ShouldContain("\r\n");
+                var withoutCrLf =
+                    markdown.Replace("\r\n", string.Empty);
+                withoutCrLf.ShouldNotContain("\r");
+                withoutCrLf.ShouldNotContain("\n");
+            }
+            finally
+            {
+                if (Directory.Exists(outDir))
+                {
+                    Directory.Delete(outDir, recursive: true);
+                }
+            }
         }
 
         private static GenerateMarkdownFromXmlDoc CreateTask(string outDir) =>

--- a/Xml2Doc/tests/Xml2Doc.Tests/MarkdownLineEndingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/MarkdownLineEndingTests.cs
@@ -1,0 +1,166 @@
+using Shouldly;
+using System;
+using System.IO;
+using System.Linq;
+using Xml2Doc.Core;
+using Xunit;
+
+namespace Xml2Doc.Tests
+{
+    public class MarkdownLineEndingTests
+    {
+        private static string TestProjectDirectory =>
+            Path.GetFullPath(
+                AppContext.BaseDirectory +
+                ".." + Path.DirectorySeparatorChar +
+                ".." + Path.DirectorySeparatorChar +
+                "..");
+
+        private static string SampleXml =>
+            TestProjectDirectory + Path.DirectorySeparatorChar +
+            "Assets" + Path.DirectorySeparatorChar +
+            "Xml2Doc.Sample.xml";
+
+        [Fact]
+        public void RenderToString_DefaultsToLfIndependentlyOfHostNewline()
+        {
+            var renderer = CreateRenderer(new RendererOptions());
+
+            var markdown = renderer.RenderToString();
+
+            markdown.ShouldContain("\n");
+            markdown.ShouldNotContain("\r");
+        }
+
+        [Fact]
+        public void RenderToString_WhenCrLfSelected_UsesOnlyCrLf()
+        {
+            var renderer = CreateRenderer(
+                new RendererOptions(LineEndings: LineEndingStyle.CrLf));
+
+            var markdown = renderer.RenderToString();
+
+            AssertUsesOnly(markdown, "\r\n");
+        }
+
+        [Fact]
+        public void RenderToString_WhenNativeSelected_UsesOnlyHostNewline()
+        {
+            var renderer = CreateRenderer(
+                new RendererOptions(LineEndings: LineEndingStyle.Native));
+
+            var markdown = renderer.RenderToString();
+
+            AssertUsesOnly(markdown, Environment.NewLine);
+        }
+
+        [Fact]
+        public void RenderToDirectory_NormalizesEveryMarkdownOutputToLf()
+        {
+            var outputDirectory =
+                Path.GetTempPath() +
+                "Xml2Doc.Tests" + Path.DirectorySeparatorChar +
+                Guid.NewGuid().ToString("N");
+
+            try
+            {
+                var renderer = CreateRenderer(
+                    new RendererOptions(EmitNamespaceIndex: true));
+
+                renderer.RenderToDirectory(outputDirectory);
+
+                var markdownFiles = Directory
+                    .GetFiles(
+                        outputDirectory,
+                        "*.md",
+                        SearchOption.AllDirectories)
+                    .ToArray();
+                markdownFiles.ShouldNotBeEmpty();
+
+                foreach (var markdownFile in markdownFiles)
+                {
+                    var content = File.ReadAllText(markdownFile);
+                    content.ShouldNotContain(
+                        "\r",
+                        $"Expected LF-only output in {markdownFile}.");
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(outputDirectory))
+                {
+                    Directory.Delete(outputDirectory, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void RenderToSingleFile_UsesConfiguredCrLfBytes()
+        {
+            var outputDirectory =
+                Path.GetTempPath() +
+                "Xml2Doc.Tests" + Path.DirectorySeparatorChar +
+                Guid.NewGuid().ToString("N");
+            var outputFile =
+                outputDirectory + Path.DirectorySeparatorChar + "api.md";
+
+            try
+            {
+                var renderer = CreateRenderer(
+                    new RendererOptions(LineEndings: LineEndingStyle.CrLf));
+
+                renderer.RenderToSingleFile(outputFile);
+
+                var bytes = File.ReadAllBytes(outputFile);
+                bytes.ShouldContain((byte)'\n');
+                (bytes.Length >= 3 &&
+                 bytes[0] == 0xEF &&
+                 bytes[1] == 0xBB &&
+                 bytes[2] == 0xBF).ShouldBeFalse(
+                    "Markdown must be UTF-8 without a byte-order mark.");
+
+                for (var index = 0; index < bytes.Length; index++)
+                {
+                    if (bytes[index] == (byte)'\n')
+                    {
+                        index.ShouldBeGreaterThan(0);
+                        bytes[index - 1].ShouldBe((byte)'\r');
+                    }
+
+                    if (bytes[index] == (byte)'\r')
+                    {
+                        index.ShouldBeLessThan(bytes.Length - 1);
+                        bytes[index + 1].ShouldBe((byte)'\n');
+                    }
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(outputDirectory))
+                {
+                    Directory.Delete(outputDirectory, recursive: true);
+                }
+            }
+        }
+
+        private static MarkdownRenderer CreateRenderer(
+            RendererOptions options)
+        {
+            File.Exists(SampleXml).ShouldBeTrue(
+                $"Missing fixture XML at: {SampleXml}");
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(SampleXml);
+            return new MarkdownRenderer(model, options);
+        }
+
+        private static void AssertUsesOnly(
+            string content,
+            string expectedLineEnding)
+        {
+            content.ShouldContain(expectedLineEnding);
+            var withoutExpected =
+                content.Replace(expectedLineEnding, string.Empty);
+            withoutExpected.ShouldNotContain("\r");
+            withoutExpected.ShouldNotContain("\n");
+        }
+    }
+}

--- a/Xml2Doc/tests/Xml2Doc.Tests/MarkdownLineEndingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/MarkdownLineEndingTests.cs
@@ -80,8 +80,7 @@ namespace Xml2Doc.Tests
                 foreach (var markdownFile in markdownFiles)
                 {
                     var content = File.ReadAllText(markdownFile);
-                    content.ShouldNotContain(
-                        "\r",
+                    content.Contains('\r').ShouldBeFalse(
                         $"Expected LF-only output in {markdownFile}.");
                 }
             }

--- a/docs/adr/ADR-013-deterministic-markdown-line-endings.md
+++ b/docs/adr/ADR-013-deterministic-markdown-line-endings.md
@@ -1,0 +1,51 @@
+# ADR-013 Deterministic Markdown Line Endings
+
+## Status
+
+Accepted
+
+## Context
+
+Markdown rendering currently relies on StringBuilder.AppendLine, which uses the host operating
+system's newline sequence. Identical XML input can therefore produce LF on Linux and CRLF on
+Windows. Templates and XML documentation can also introduce mixed newline sequences. This creates
+large documentation-only diffs in consumer repositories such as BAT vNext and makes output bytes
+depend on workstation and Git configuration.
+
+## Decision
+
+1. Core owns the Markdown line-ending policy through RendererOptions.
+2. LF is the default on every supported host so identical input and options produce byte-identical
+   Markdown independent of Environment.NewLine.
+3. Callers may explicitly select CRLF or the current host's native newline for compatibility.
+4. Core normalizes CRLF, LF, and lone CR sequences at the final Markdown output boundary. This
+   applies to per-type pages, indexes, namespace pages, single-file output, templates, front matter,
+   and in-memory rendering.
+5. CLI and MSBuild expose the same Core setting. They do not perform their own newline conversion.
+6. Markdown files are written as UTF-8 without a byte-order mark so encoding bytes are also stable
+   across target frameworks and hosts.
+7. The policy applies to generated Markdown, not JSON reports or lifecycle manifests.
+
+## Consequences
+
+- Default Markdown output is stable across Windows, Linux, and macOS.
+- Existing consumers that require CRLF or native output can opt in explicitly.
+- A first build after adopting the LF default may produce a one-time line-ending-only diff for files
+  previously generated as CRLF.
+- .gitattributes remains useful repository policy, but it is not required for renderer determinism.
+
+## Alternatives Considered
+
+### Use the platform-native newline by default
+
+Rejected because it preserves the cross-platform instability reported in issue #67.
+
+### Rely exclusively on .gitattributes or Git core.autocrlf
+
+Rejected because renderer output must be deterministic before Git processes the file, and consumers
+may generate documentation outside a Git worktree.
+
+### Normalize only at file-write call sites
+
+Rejected because RenderToString is also public output and must follow the same deterministic
+contract. A shared final-output boundary keeps file and in-memory behavior aligned.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,17 +6,18 @@ These records explain **why architectural decisions were made**.
 
 ## ADR index
 
-| ADR     | Title                          | Status   |
-| ------- | ------------------------------ | -------- |
-| ADR‑001 | Scope and non‑goals            | Accepted |
-| ADR‑002 | Solution structure             | Accepted |
-| ADR‑003 | Markdown output modes          | Accepted |
-| ADR‑004 | Shared configuration model     | Accepted |
-| ADR‑005 | Regression strategy            | Accepted |
-| ADR‑006 | Link and anchor stability      | Accepted |
-| ADR‑007 | MSBuild incremental generation | Accepted |
-| ADR‑008 | Multi‑target compatibility     | Accepted |
-| ADR‑009 | Structured diagnostics         | Proposed |
-| ADR‑010 | Pluggable anchor algorithms    | Proposed |
-| ADR‑011 | Generated output ownership     | Accepted |
-| ADR‑012 | Invocation-scoped manifest identity | Accepted |
+| ADR | Title | Status |
+| --- | --- | --- |
+| ADR-001 | Scope and non-goals | Accepted |
+| ADR-002 | Solution structure | Accepted |
+| ADR-003 | Markdown output modes | Accepted |
+| ADR-004 | Shared configuration model | Accepted |
+| ADR-005 | Regression strategy | Accepted |
+| ADR-006 | Link and anchor stability | Accepted |
+| ADR-007 | MSBuild incremental generation | Accepted |
+| ADR-008 | Multi-target compatibility | Accepted |
+| ADR-009 | Structured diagnostics | Proposed |
+| ADR-010 | Pluggable anchor algorithms | Proposed |
+| ADR-011 | Generated output ownership | Accepted |
+| ADR-012 | Invocation-scoped manifest identity and storage | Accepted |
+| ADR-013 | Deterministic Markdown line endings | Accepted |


### PR DESCRIPTION
## Summary

- make LF the deterministic default for every generated Markdown output
- add explicit LF, CRLF, and platform-native line-ending policies in Core
- expose the policy through CLI configuration and MSBuild properties
- write Markdown as UTF-8 without a byte-order mark
- validate the full test suite on Windows, Linux, and macOS

## Root cause

Markdown content is assembled with `StringBuilder.AppendLine()`, which uses the host operating system's newline sequence. The renderer previously wrote those strings directly, so identical XML input produced different bytes on Windows and Unix-like hosts. Embedded content could also introduce mixed newline sequences.

## Behavior

- `LF` is the default on every platform.
- `CRLF` and `Native` remain available as explicit compatibility choices.
- Core normalizes all Markdown at the final output boundary, including per-type pages, indexes, namespace pages, single-file output, and `RenderToString()`.
- JSON reports and lifecycle manifests are unchanged.

## Host configuration

- CLI: `--line-endings <lf|crlf|native>`
- JSON config: `LineEndings`
- MSBuild: `Xml2Doc_LineEndings`

## Testing

- default LF and explicit CRLF/native rendering
- byte-level CRLF and UTF-8-without-BOM assertions
- every per-type and namespace Markdown output
- CLI validation and CLI-over-config precedence
- MSBuild validation, wiring, and generated output
- Windows, Linux, and macOS GitHub Actions matrix

Static validation completed locally:

- `git diff --check`
- MSBuild props/targets XML parsing
- workflow YAML parsing

The local environment does not provide the .NET SDK, so GitHub Actions is the authoritative compile and runtime validation.

## Architecture

Adds accepted ADR-013, Deterministic Markdown Line Endings.

Closes #67.