### PR TITLE
Fix MSBuild package dependency bundling for 2.0.2

### DIFF
--- a/.github/workflows/msbuild-package-integration.yml
+++ b/.github/workflows/msbuild-package-integration.yml
@@ -1,0 +1,34 @@
+name: MSBuild Package Integration
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "Xml2Doc/src/Xml2Doc.Core/**"
+      - "Xml2Doc/src/Xml2Doc.MSBuild/**"
+      - "scripts/test-msbuild-package.ps1"
+      - ".github/workflows/msbuild-package-integration.yml"
+      - ".github/workflows/release.yml"
+      - "Directory.Build.props"
+      - "global.json"
+
+jobs:
+  verify_package:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET (global.json)
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: ./global.json
+
+      - name: Verify package layout and clean consumer
+        shell: pwsh
+        run: ./scripts/test-msbuild-package.ps1 -Configuration Release
+

--- a/.github/workflows/msbuild-package-integration.yml
+++ b/.github/workflows/msbuild-package-integration.yml
@@ -13,6 +13,9 @@ on:
       - "Directory.Build.props"
       - "global.json"
 
+permissions:
+  contents: read
+
 jobs:
   verify_package:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,15 @@ jobs:
           # Pack MSBuild Package
           dotnet pack ${{ github.workspace }}/Xml2Doc/src/Xml2Doc.MSBuild/Xml2Doc.MSBuild.csproj --configuration Release --output ./publish --no-build
 
+      - name: Verify MSBuild package
+        shell: pwsh
+        run: >
+          ./scripts/test-msbuild-package.ps1
+          -Configuration Release
+          -UseExistingPackage
+          -PackageDirectory "${{ github.workspace }}/publish"
+          -PackageVersion "${{ env.VERSION }}"
+
       - name: Push to NuGet
         run: dotnet nuget push ./publish/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <RepositoryType>git</RepositoryType>
 
     <!-- Version: set once for all (override per project if needed) -->
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <!-- Licensing (metadata only; LICENSE lives in repo root) -->
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/Xml2Doc/src/Xml2Doc.MSBuild/Xml2Doc.MSBuild.csproj
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/Xml2Doc.MSBuild.csproj
@@ -16,6 +16,9 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);_PackTaskDependencies</TargetsForTfmSpecificBuildOutput>
+
+    <!-- The task package embeds its runtime dependencies, so dependency groups are intentionally absent. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
     
     <!-- NuGet metadata -->
     <PackageId>Xml2Doc.MSBuild</PackageId>

--- a/Xml2Doc/src/Xml2Doc.MSBuild/Xml2Doc.MSBuild.csproj
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/Xml2Doc.MSBuild.csproj
@@ -15,6 +15,7 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);_PackTaskDependencies</TargetsForTfmSpecificBuildOutput>
     
     <!-- NuGet metadata -->
     <PackageId>Xml2Doc.MSBuild</PackageId>
@@ -69,20 +70,26 @@
           Condition="Exists('build\Xml2Doc.MSBuild.props')" />
   </ItemGroup>
 
-  <Target Name="_PackTaskDeps" AfterTargets="Build">
+  <Target Name="_PackTaskDependencies">
     <ItemGroup>
-      <!-- Take everything we built next to the task -->
-      <_TaskFiles Include="$(TargetDir)*.dll;$(TargetDir)*.pdb;$(TargetDir)*.xml" />
+      <!-- Include task-local dependencies when NuGet gathers each TFM's build output. -->
+      <_TaskDependency Include="$(TargetDir)*.dll;$(TargetDir)*.pdb;$(TargetDir)*.xml" />
+
+      <!-- The SDK already includes the task assembly and its symbols/docs. -->
+      <_TaskDependency Remove="$(TargetDir)Xml2Doc.MSBuild.dll" />
+      <_TaskDependency Remove="$(TargetDir)Xml2Doc.MSBuild.pdb" />
+      <_TaskDependency Remove="$(TargetDir)Xml2Doc.MSBuild.xml" />
 
       <!-- But exclude MSBuild toolset binaries; let MSBuild provide those -->
-      <_TaskFiles Remove="$(TargetDir)Microsoft.Build.*.dll" />
-      <_TaskFiles Remove="$(TargetDir)Microsoft.NET.StringTools.dll" />
-      <_TaskFiles Remove="$(TargetDir)Microsoft.IO.Redist.dll" />
+      <_TaskDependency Remove="$(TargetDir)Microsoft.Build.*.dll" />
+      <_TaskDependency Remove="$(TargetDir)Microsoft.NET.StringTools.dll" />
+      <_TaskDependency Remove="$(TargetDir)Microsoft.IO.Redist.dll" />
 
-      <!-- Map them into the lib/<tfm>/ area in the package -->
-      <TfmSpecificPackageFile Include="@(_TaskFiles)">
-        <PackagePath>lib\$(TargetFramework)\%(Filename)%(Extension)</PackagePath>
-      </TfmSpecificPackageFile>
+      <!-- NuGet places BuildOutputInPackage items under lib/<tfm>/. -->
+      <BuildOutputInPackage Include="@(_TaskDependency)">
+        <FinalOutputPath>%(FullPath)</FinalOutputPath>
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      </BuildOutputInPackage>
     </ItemGroup>
   </Target>
 </Project>

--- a/scripts/test-msbuild-package.ps1
+++ b/scripts/test-msbuild-package.ps1
@@ -33,10 +33,19 @@ function Invoke-DotNet
   )
 
   Write-Host "    dotnet $($Arguments -join ' ')"
-  & dotnet @Arguments 2>&1 | ForEach-Object { Write-Host $_ }
-  if ($LASTEXITCODE -ne 0)
+  Push-Location -LiteralPath $WorkingDirectory
+  try
   {
-    throw "dotnet $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    & dotnet @Arguments 2>&1 | ForEach-Object { Write-Host $_ }
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0)
+    {
+      throw "dotnet $($Arguments -join ' ') failed with exit code $exitCode."
+    }
+  }
+  finally
+  {
+    Pop-Location
   }
 }
 

--- a/scripts/test-msbuild-package.ps1
+++ b/scripts/test-msbuild-package.ps1
@@ -102,7 +102,15 @@ try
   Assert-True (Test-Path -LiteralPath $packagePath -PathType Leaf) "Expected package was not found: $packagePath"
 
   Write-Step "Inspecting package contents"
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  try
+  {
+    Add-Type -AssemblyName System.IO.Compression.ZipFile -ErrorAction Stop
+  }
+  catch
+  {
+    # Windows PowerShell on .NET Framework exposes ZipFile through this assembly.
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+  }
   $archive = [System.IO.Compression.ZipFile]::OpenRead($packagePath)
   try
   {

--- a/scripts/test-msbuild-package.ps1
+++ b/scripts/test-msbuild-package.ps1
@@ -1,0 +1,207 @@
+[CmdletBinding()]
+param(
+  [ValidateSet("Debug", "Release")]
+  [string] $Configuration = "Release",
+
+  [string] $PackageDirectory,
+
+  [string] $PackageVersion,
+
+  [switch] $UseExistingPackage,
+
+  [switch] $KeepArtifacts
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step([string] $Message)
+{
+  Write-Host ""
+  Write-Host "==> $Message"
+}
+
+function Assert-True($Condition, [string] $Message)
+{
+  if (-not $Condition) { throw $Message }
+}
+
+function Invoke-DotNet
+{
+  param(
+    [Parameter(Mandatory = $true)][string[]] $Arguments,
+    [Parameter(Mandatory = $true)][string] $WorkingDirectory
+  )
+
+  Write-Host "    dotnet $($Arguments -join ' ')"
+  & dotnet @Arguments 2>&1 | ForEach-Object { Write-Host $_ }
+  if ($LASTEXITCODE -ne 0)
+  {
+    throw "dotnet $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+  }
+}
+
+$repo = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$propsPath = Join-Path $repo "Directory.Build.props"
+$taskProject = Join-Path $repo "Xml2Doc/src/Xml2Doc.MSBuild/Xml2Doc.MSBuild.csproj"
+
+[xml] $props = Get-Content -LiteralPath $propsPath -Raw
+$versionPrefix = $props.SelectSingleNode("/Project/PropertyGroup/VersionPrefix").InnerText
+Assert-True (-not [string]::IsNullOrWhiteSpace($versionPrefix)) "VersionPrefix was not found in Directory.Build.props."
+
+if ([string]::IsNullOrWhiteSpace($PackageVersion))
+{
+  $PackageVersion = "$versionPrefix-package-test"
+}
+
+$runRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("xml2doc-package-test-" + [guid]::NewGuid().ToString("n"))
+$consumerRoot = Join-Path $runRoot "consumer"
+
+if ([string]::IsNullOrWhiteSpace($PackageDirectory))
+{
+  $PackageDirectory = Join-Path $runRoot "packages"
+}
+elseif (-not [System.IO.Path]::IsPathRooted($PackageDirectory))
+{
+  $PackageDirectory = Join-Path $repo $PackageDirectory
+}
+
+New-Item -ItemType Directory -Force -Path $PackageDirectory | Out-Null
+New-Item -ItemType Directory -Force -Path $consumerRoot | Out-Null
+
+try
+{
+  if (-not $UseExistingPackage)
+  {
+    Write-Step "Building Xml2Doc.MSBuild and its project dependencies"
+    Invoke-DotNet -WorkingDirectory $repo -Arguments @(
+      "build", $taskProject,
+      "--configuration", $Configuration,
+      "--disable-build-servers"
+    )
+
+    Write-Step "Packing with the release workflow's --no-build sequence"
+    Invoke-DotNet -WorkingDirectory $repo -Arguments @(
+      "pack", $taskProject,
+      "--configuration", $Configuration,
+      "--output", $PackageDirectory,
+      "--no-build",
+      "-p:PackageVersion=$PackageVersion"
+    )
+  }
+
+  $packagePath = Join-Path $PackageDirectory "Xml2Doc.MSBuild.$PackageVersion.nupkg"
+  Assert-True (Test-Path -LiteralPath $packagePath -PathType Leaf) "Expected package was not found: $packagePath"
+
+  Write-Step "Inspecting package contents"
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  $archive = [System.IO.Compression.ZipFile]::OpenRead($packagePath)
+  try
+  {
+    $entries = @($archive.Entries | ForEach-Object { $_.FullName -replace '\\', '/' })
+  }
+  finally
+  {
+    $archive.Dispose()
+  }
+
+  $requiredEntries = @(
+    "lib/net472/Xml2Doc.MSBuild.dll",
+    "lib/net472/Xml2Doc.Core.dll",
+    "lib/net472/System.Text.Json.dll",
+    "lib/net8.0/Xml2Doc.MSBuild.dll",
+    "lib/net8.0/Xml2Doc.Core.dll"
+  )
+
+  foreach ($entry in $requiredEntries)
+  {
+    Assert-True ($entries -contains $entry) "Package is missing required entry '$entry'."
+    Write-Host "    Found: $entry"
+  }
+
+  $forbiddenEntries = @(
+    "lib/net472/Microsoft.Build.Framework.dll",
+    "lib/net472/Microsoft.Build.Utilities.Core.dll",
+    "lib/net8.0/Microsoft.Build.Framework.dll",
+    "lib/net8.0/Microsoft.Build.Utilities.Core.dll"
+  )
+
+  foreach ($entry in $forbiddenEntries)
+  {
+    Assert-True ($entries -notcontains $entry) "Package must not contain MSBuild-owned assembly '$entry'."
+  }
+
+  Write-Step "Creating clean net9.0 consumer"
+  $consumerProject = @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Xml2Doc_Enabled>true</Xml2Doc_Enabled>
+    <Xml2Doc_OutputDir>$(MSBuildProjectDirectory)/docs</Xml2Doc_OutputDir>
+    <Xml2Doc_ReportPath>$(MSBuildProjectDirectory)/docs/xml2doc-report.json</Xml2Doc_ReportPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Xml2Doc.MSBuild" Version="__PACKAGE_VERSION__" PrivateAssets="all" />
+  </ItemGroup>
+</Project>
+'@.Replace("__PACKAGE_VERSION__", $PackageVersion)
+
+  $consumerSource = @'
+namespace PackageConsumer;
+
+/// <summary>Type used to prove the packaged MSBuild task can load and execute.</summary>
+public sealed class Example
+{
+    /// <summary>Returns a deterministic value.</summary>
+    public int GetValue() => 42;
+}
+'@
+
+  $nugetConfig = @'
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="__PACKAGE_DIRECTORY__" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+'@.Replace("__PACKAGE_DIRECTORY__", [System.Security.SecurityElement]::Escape($PackageDirectory))
+
+  Set-Content -LiteralPath (Join-Path $consumerRoot "PackageConsumer.csproj") -Value $consumerProject -Encoding utf8
+  Set-Content -LiteralPath (Join-Path $consumerRoot "Example.cs") -Value $consumerSource -Encoding utf8
+  Set-Content -LiteralPath (Join-Path $consumerRoot "NuGet.Config") -Value $nugetConfig -Encoding utf8
+
+  Write-Step "Restoring clean consumer from the local package"
+  Invoke-DotNet -WorkingDirectory $consumerRoot -Arguments @(
+    "restore", "PackageConsumer.csproj",
+    "--configfile", "NuGet.Config"
+  )
+
+  Write-Step "Building clean consumer"
+  Invoke-DotNet -WorkingDirectory $consumerRoot -Arguments @(
+    "build", "PackageConsumer.csproj",
+    "--configuration", $Configuration,
+    "--no-restore",
+    "--disable-build-servers"
+  )
+
+  $generatedIndex = Join-Path $consumerRoot "docs/index.md"
+  $generatedReport = Join-Path $consumerRoot "docs/xml2doc-report.json"
+  Assert-True (Test-Path -LiteralPath $generatedIndex -PathType Leaf) "Clean consumer did not generate docs/index.md."
+  Assert-True (Test-Path -LiteralPath $generatedReport -PathType Leaf) "Clean consumer did not generate xml2doc-report.json."
+
+  Write-Step "MSBuild package integration completed successfully"
+  Write-Host "Package: $packagePath"
+}
+finally
+{
+  if ($KeepArtifacts)
+  {
+    Write-Host "Keeping test artifacts: $runRoot"
+  }
+  elseif (Test-Path -LiteralPath $runRoot)
+  {
+    Remove-Item -LiteralPath $runRoot -Recurse -Force
+  }
+}


### PR DESCRIPTION
## Summary

- include `Xml2Doc.Core` and required runtime assemblies in the `Xml2Doc.MSBuild` package for each target framework
- package dependencies through `TargetsForTfmSpecificBuildOutput`, including when release packaging uses `--no-build`
- add a Windows/Linux package integration workflow using a clean .NET 9 consumer
- verify the MSBuild package before publishing in the release workflow
- update the package version to `2.0.2`
- suppress the expected `NU5128` warning because the task package intentionally embeds its runtime dependencies

## Validation

Manually validated on Windows with .NET SDK 9.0.317:

- built `Xml2Doc.MSBuild` for `net472` and `net8.0`
- packed with the release workflow's `--no-build` sequence
- confirmed `Xml2Doc.Core.dll` and required runtime assemblies are present in the package
- restored the local package into a clean `net9.0` consumer
- successfully executed the MSBuild task and generated Markdown plus the JSON report
- consumer build completed with 0 warnings and 0 errors

Closes #75