### PR TITLE
Update roadmap and Xml2Doc 2.0.2 configuration guide

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,9 +5,10 @@ This roadmap groups the current open issues into focused release milestones. Mil
 ## Release sequence
 
 1. `2.0.1` — Documentation Correctness
-2. `2.1.0` — Rendering Extensibility
-3. `2.2.0` — Diagnostics and Pipeline
-4. `2.3.0` — Multi-project Aggregation
+2. `2.0.3` — Portable Output Lifecycle State
+3. `2.1.0` — Rendering Extensibility
+4. `2.2.0` — Diagnostics and Pipeline
+5. `2.3.0` — Multi-project Aggregation
 
 ## 2.0.1 — Documentation Correctness
 
@@ -21,6 +22,21 @@ Completion criteria:
 - Valid XML documentation constructs no longer produce missing or incomplete Markdown.
 - Regression tests cover language keywords, explicit inheritance references, interface implementations, and overloaded members.
 - Existing `<see cref="..."/>` rendering remains unchanged.
+
+## 2.0.3 — Portable Output Lifecycle State
+
+Make stale-output ownership portable across repository checkout locations while preserving safe deletion boundaries.
+
+- [ ] [#77 — Make stale-output ownership manifests portable across checkout paths](https://github.com/mod-posh/xml2doc/issues/77)
+
+Completion criteria:
+
+- Repository-relative output ownership can survive different absolute checkout locations.
+- Manifest paths remain deterministic for stable project identities.
+- A manifest cannot authorize traversal or deletion outside the current output root.
+- Existing manifests migrate safely or fail with an actionable compatibility message.
+- Tests cover Windows and Unix checkout roots, repository relocation, and multiple projects sharing one output directory.
+- Documentation defines which lifecycle metadata is portable and which files should remain ignored.
 
 ## 2.1.0 — Rendering Extensibility
 

--- a/Xml2Doc.md
+++ b/Xml2Doc.md
@@ -1,207 +1,320 @@
 # Xml2Doc
 
-Xml2Doc turns the XML documentation your C# compiler already emits into clean, linkable Markdown.
-Use it as a **library**, a **CLI**, or via an **MSBuild task** right inside your build.
+Xml2Doc converts C# compiler XML documentation into deterministic, linkable Markdown. It is available as a library, CLI, and MSBuild package.
 
-- ✅ Modern .NET support with deterministic output across TFMs
-- ✅ Works locally, in CI, or inside Visual Studio
-- ✅ Snapshot-tested, link- and anchor-stable Markdown
+## Current status
 
----
+The current stable package line is `2.0.2`:
 
-## 📖 Overview
+- `Xml2Doc.Core` provides parsing, rendering, output ownership, stale-file pruning, and line-ending normalization.
+- `Xml2Doc.Cli` provides repeatable command-line generation for development and CI.
+- `Xml2Doc.MSBuild` generates documentation automatically after compilation.
+- Per-type and single-file output are supported.
+- Markdown uses LF on every platform by default.
+- Multiple projects can safely share an output directory when they have distinct manifest identities and disable their project-owned indexes.
+- Unified multi-project index aggregation is planned for `2.3.0`. Until then, maintain or generate the repository index separately.
+- Ownership manifests are local workspace state in 2.0.2. Portable manifests are tracked by [issue #77](https://github.com/mod-posh/xml2doc/issues/77) for the proposed `2.0.3` milestone.
 
-Xml2Doc includes:
+## Supported frameworks
 
-- **Xml2Doc.Core** — Engine that parses XML and renders Markdown.
-- **Xml2Doc.Cli** — Command-line tool for repeatable conversions.
-- **Xml2Doc.MSBuild** — Build integration that generates docs after a successful compile.
+| Component | Target frameworks | Purpose |
+| --- | --- | --- |
+| `Xml2Doc.Core` | `netstandard2.0`, `net8.0`, `net9.0` | Library and renderer |
+| `Xml2Doc.Cli` | `net8.0`, `net9.0` | Command-line host |
+| `Xml2Doc.MSBuild` | `net472`, `net8.0` | Visual Studio/MSBuild.exe and `dotnet build` task hosts |
 
-Key capabilities:
+The MSBuild package selects its task assembly automatically. Do not define a custom `GenerateMarkdownFromXmlDoc` target or manually call `Xml2Doc_ComputeFingerprint`.
 
-- Converts `<summary>`, `<remarks>`, `<example>`, `<seealso>`, `<exception>`, `<inheritdoc/>`.
-- Auto-links `<see cref="…"/>` and `<paramref name="…"/>`.
-- Overload grouping under a single heading.
-- Short, readable generics (`List<T>`), token-aware primitive aliases (`System.String → string` without breaking identifiers).
-- **Per-type** and **single-file** output modes.
-- Stable, explicit anchors for members; GitHub-style heading slugs for types (single-file).
-- Paragraph/code-fence preserving normalization.
-- Filename modes: `verbatim` or `clean`.
-- Configurable code block language (default `csharp`) and display-only root namespace trimming.
+## Install the MSBuild package
 
----
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 
-## 🧭 Multi-framework support
-
-| Component           | Target Frameworks                               | Notes |
-|--------------------|--------------------------------------------------|-------|
-| **Xml2Doc.Core**   | `netstandard2.0; net8.0; net9.0`                 | Output is **identical** across TFMs (tested). |
-| **Xml2Doc.Cli**    | `net8.0; net9.0`                                 | Build both; run the artifact for the TFM available on your machine. |
-| **Xml2Doc.MSBuild**| `net472; net8.0`                                 | VS/MSBuild.exe hosts the **net472** task; `dotnet build` hosts the **net8.0** task. |
-
-### Source/compat notes
-
-- We keep C# 10 syntax in source (file-scoped namespaces/global usings) while avoiding runtime-only APIs missing on `netstandard2.0` (e.g., `Index`/`Range`, certain `Split` overloads).
-- The MSBuild task maps to the correct Core TFM automatically (e.g., task `net472` → Core `netstandard2.0`).
-
----
-
-## 🔗 Link behavior & anchors (summary)
-
-- **Per-type (`RenderToDirectory`)**
-  - Types link to per-type files; members link to anchors inside those files.
-- **Single-file (`RenderToSingleFile` / `RenderToString`)**
-  - Types use heading slugs; members use explicit in-document anchors.
-
-Anchors are stable and case-normalized, with safe generic brace handling (e.g., `Dictionary{String,Int32}` → `dictionary[string,int]`).
-
----
-
-## 🧱 Project layout
-
+  <ItemGroup>
+    <PackageReference Include="Xml2Doc.MSBuild" Version="2.0.2" PrivateAssets="all">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
 ```
 
-Xml2Doc/
-├─ src/
-│  ├─ Xml2Doc.Core/
-│  ├─ Xml2Doc.Cli/
-│  └─ Xml2Doc.MSBuild/
-├─ tests/
-│  ├─ Xml2Doc.Tests/
-│  └─ Xml2Doc.Sample/
-├─ Directory.Build.props
-├─ Xml2Doc.sln
-├─ README.md
-└─ CHANGELOG.md
+`GenerateDocumentationFile` must be `true`. The package imports its own generation and incremental-build targets.
 
-````
+## Where properties belong
 
----
+Most Xml2Doc properties can be placed in either:
 
-## 🚀 Quick start
+- A `.csproj` for project-specific behavior.
+- A solution-level `Directory.Build.props` for shared behavior.
 
-### 1) Enable XML documentation in your project
+Project properties override `Directory.Build.props`. Avoid defining a property in both unless the override is intentional.
+
+Keep string values such as the root namespace on one line. In 2.0.2, surrounding whitespace is preserved and can prevent prefix matching:
+
+```xml
+<Xml2Doc_RootNamespaceToTrim>Rackspace.BAT.Core</Xml2Doc_RootNamespaceToTrim>
+```
+
+The package currently assigns `Xml2Doc_Toc`, `Xml2Doc_NamespaceIndex`, and `Xml2Doc_BasenameOnly` unconditionally in its imported defaults. To enable them in 2.0.2, set them in the `.csproj` or `Directory.Build.targets`; a `Directory.Build.props` value may be overwritten.
+
+## Complete MSBuild property reference
+
+### Generation and output
+
+| Property | Default | Values | Behavior |
+| --- | --- | --- | --- |
+| `GenerateDocumentationFile` | SDK-dependent | `true`, `false` | Required compiler property. Set it to `true` for participating projects. |
+| `Xml2Doc_Enabled` | `true` | `true`, `false` | Enables or disables automatic generation. |
+| `Xml2Doc_SingleFile` | `false` | `true`, `false` | `false` writes one file per type; `true` writes one combined file. |
+| `Xml2Doc_OutputDir` | `$(MSBuildProjectDirectory)\docs` | Directory path | Output root for per-type mode. |
+| `Xml2Doc_OutputFile` | `$(MSBuildProjectDirectory)\docs\api.md` | File path | Output used in single-file mode. |
+| `Xml2Doc_GenerateIndex` | `true` | `true`, `false` | Writes `index.md` in per-type mode. Set `false` when independent projects share a directory. |
+
+Stale-file pruning is supported only in per-type mode. Single-file mode replaces its configured output directly.
+
+### Naming, links, and rendering
+
+| Property | Default | Values | Behavior |
+| --- | --- | --- | --- |
+| `Xml2Doc_FileNameMode` | `clean` | `clean`, `verbatim` | `clean` removes generic arity and normalizes generic notation; `verbatim` preserves documentation identifiers. |
+| `Xml2Doc_RootNamespaceToTrim` | Empty | Namespace prefix | Removes a matching prefix from displayed type names. |
+| `Xml2Doc_TrimRootNamespaceInFileNames` | `false` | `true`, `false` | Also removes the configured root namespace from filenames. |
+| `Xml2Doc_CodeBlockLanguage` | `csharp` | Fence language | Default fenced-code language. |
+| `Xml2Doc_AnchorAlgorithm` | `default` | `default`, `github`, `gfm`, `kramdown` | Controls heading/member anchors. Changing it can break published fragment links. |
+| `Xml2Doc_Toc` | `false` | `true`, `false` | Emits a member table of contents where supported. Set in `.csproj` or `Directory.Build.targets` in 2.0.2. |
+| `Xml2Doc_NamespaceIndex` | `false` | `true`, `false` | Emits namespace index output in per-type mode. Set in `.csproj` or `Directory.Build.targets` in 2.0.2. |
+| `Xml2Doc_BasenameOnly` | `false` | `true`, `false` | Drops namespace segments from filenames and increases collision risk. Set in `.csproj` or `Directory.Build.targets` in 2.0.2. |
+| `Xml2Doc_LineEndings` | `lf` | `lf`, `crlf`, `native` | Normalizes generated Markdown at the output boundary. `lf` is deterministic across hosts. |
+
+Filename processing order is: filename-mode normalization, optional root-namespace trimming, then optional basename-only reduction.
+
+### Ownership and stale cleanup
+
+| Property | Default | Values | Behavior |
+| --- | --- | --- | --- |
+| `Xml2Doc_PruneStaleFiles` | `false` | `true`, `false` | After successful per-type generation, removes files previously owned by the same identity that are no longer generated. |
+| `Xml2Doc_ManifestIdentity` | Empty | Stable string | Required for pruning. Use a distinct stable value for every project sharing an output directory, such as `$(MSBuildProjectName)`. |
+
+Xml2Doc deletes only stale paths recorded in the prior manifest for the same identity. It does not claim hand-authored documents or files owned by another project.
+
+Lifecycle metadata is stored under:
+
+```text
+<output-root>/.xml2doc/
+├── manifests/
+│   └── <identity-sha256>.json
+└── transactions/
+```
+
+The transactions directory is normally empty after a successful build. Temporary child directories stage stale files while the manifest is replaced and are then removed. In 2.0.2, ignore `.xml2doc` because its manifests record an absolute output root and are not portable between checkout paths; see issue #77.
+
+### Reports and diagnostics
+
+| Property | Default | Values | Behavior |
+| --- | --- | --- | --- |
+| `Xml2Doc_ReportPath` | `$(Xml2Doc_OutputDir)\xml2doc-report.json` | File path | Writes a JSON report. Use unique names for projects sharing a directory. Reports are not needed for pruning. |
+| `Xml2Doc_ReportIncludeTimestamp` | `false` | `true`, `false` | Adds a timestamp. Leave false for deterministic reports. |
+| `Xml2Doc_DryRun` | `false` | `true`, `false` | Plans output without writing Markdown; a configured report can still be written. |
+| `Xml2Doc_Dump` | `false` | `true`, `false` | Logs evaluated paths and key generation inputs. |
+| `Xml2Doc_LogChosenTask` | `false` | `true`, `false` | Logs the selected task TFM and assembly path. |
+| `Xml2Doc_Diff` | `false` | Reserved | Has no effect in 2.0.2. |
+
+Reports and local lifecycle state may be ignored:
+
+```gitignore
+docs/xml2doc-report*.json
+docs/.xml2doc/
+```
+
+### Incremental-build controls
+
+These are advanced settings; most consumers should retain the defaults.
+
+| Property | Default | Behavior |
+| --- | --- | --- |
+| `Xml2Doc_OutputStamp` | `$(IntermediateOutputPath)xml2doc.stamp` | Successful-generation stamp used by MSBuild input/output tracking. Relative paths are rooted under `IntermediateOutputPath`. |
+| `Xml2Doc_FingerprintFile` | `$(IntermediateOutputPath)xml2doc.fingerprint.txt` | Stores a fingerprint of XML content and significant options. Relative paths are rooted under `IntermediateOutputPath`. |
+
+Do not add an `Xml2Doc_WriteFingerprint` target. The imported targets already manage fingerprinting and generation.
+
+## Recommended single-project configuration
+
+```xml
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  <Xml2Doc_Enabled>true</Xml2Doc_Enabled>
+  <Xml2Doc_SingleFile>false</Xml2Doc_SingleFile>
+  <Xml2Doc_OutputDir>$(MSBuildProjectDirectory)\docs</Xml2Doc_OutputDir>
+  <Xml2Doc_FileNameMode>clean</Xml2Doc_FileNameMode>
+  <Xml2Doc_RootNamespaceToTrim>MyCompany.MyProduct</Xml2Doc_RootNamespaceToTrim>
+  <Xml2Doc_TrimRootNamespaceInFileNames>true</Xml2Doc_TrimRootNamespaceInFileNames>
+  <Xml2Doc_PruneStaleFiles>true</Xml2Doc_PruneStaleFiles>
+  <Xml2Doc_ManifestIdentity>$(MSBuildProjectName)</Xml2Doc_ManifestIdentity>
+  <Xml2Doc_LineEndings>lf</Xml2Doc_LineEndings>
+</PropertyGroup>
+```
+
+## Recommended shared-output configuration
+
+Put shared settings in the solution-level `Directory.Build.props`:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <Xml2Doc_Enabled>true</Xml2Doc_Enabled>
+    <Xml2Doc_SingleFile>false</Xml2Doc_SingleFile>
+    <Xml2Doc_OutputDir>$(MSBuildThisFileDirectory)docs</Xml2Doc_OutputDir>
+
+    <Xml2Doc_FileNameMode>clean</Xml2Doc_FileNameMode>
+    <Xml2Doc_RootNamespaceToTrim>Rackspace.BAT.Core</Xml2Doc_RootNamespaceToTrim>
+    <Xml2Doc_TrimRootNamespaceInFileNames>true</Xml2Doc_TrimRootNamespaceInFileNames>
+    <Xml2Doc_CodeBlockLanguage>csharp</Xml2Doc_CodeBlockLanguage>
+
+    <Xml2Doc_GenerateIndex>false</Xml2Doc_GenerateIndex>
+    <Xml2Doc_PruneStaleFiles>true</Xml2Doc_PruneStaleFiles>
+    <Xml2Doc_ManifestIdentity>$(MSBuildProjectName)</Xml2Doc_ManifestIdentity>
+
+    <Xml2Doc_ReportPath>$(Xml2Doc_OutputDir)\xml2doc-report-$(MSBuildProjectName).json</Xml2Doc_ReportPath>
+    <Xml2Doc_LineEndings>lf</Xml2Doc_LineEndings>
+  </PropertyGroup>
+</Project>
+```
+
+Each participating `.csproj` still needs:
 
 ```xml
 <PropertyGroup>
   <GenerateDocumentationFile>true</GenerateDocumentationFile>
 </PropertyGroup>
-````
 
-Build your project to produce `MyLib.xml`.
-
----
-
-### 2) Use the CLI
-
-**Build both CLI TFMs** (default for the project), then **run the built artifact** you prefer:
-
-```bash
-# Build (Release)
-dotnet build Xml2Doc/src/Xml2Doc.Cli/Xml2Doc.Cli.csproj -c Release
-
-# Run the net8.0 artifact
-dotnet Xml2Doc/src/Xml2Doc.Cli/bin/Release/net8.0/Xml2Doc.Cli.dll \
-  --xml path/to/MyLib.xml --out ./docs
-
-# Or the net9.0 artifact
-dotnet Xml2Doc/src/Xml2Doc.Cli/bin/Release/net9.0/Xml2Doc.Cli.dll \
-  --xml path/to/MyLib.xml --out ./docs
-```
-
-> Tip: Avoid `dotnet run` with multi-targeted projects. If you do use it, you **must** specify `--framework net8.0` (or `net9.0`) and ensure no custom target invokes MSBuild with a malformed `Properties=` value.
-
-**Single-file example:**
-
-```bash
-dotnet Xml2Doc/src/Xml2Doc.Cli/bin/Release/net8.0/Xml2Doc.Cli.dll \
-  --xml ./bin/Release/net9.0/MyLib.xml \
-  --out ./docs/api.md --single --file-names clean
-```
-
----
-
-### 3) Use the MSBuild task (auto-generate on build)
-
-Add to your library’s `.csproj`:
-
-```xml
 <ItemGroup>
-  <PackageReference Include="Xml2Doc.MSBuild" Version="1.1.0" PrivateAssets="all" />
+  <PackageReference Include="Xml2Doc.MSBuild" Version="2.0.2" PrivateAssets="all">
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  </PackageReference>
 </ItemGroup>
 ```
 
-**Properties:**
+Retaining a project-distinguishing namespace segment prevents collisions. Trimming `Rackspace.BAT.Core`, for example, produces:
 
-| Property                      | Description                             |
-| ----------------------------- | --------------------------------------- |
-| `Xml2Doc_Enabled`             | Enable/disable (default `true`)         |
-| `Xml2Doc_SingleFile`          | `true` → one Markdown file              |
-| `Xml2Doc_OutputFile`          | Output file path (single-file mode)     |
-| `Xml2Doc_OutputDir`           | Output directory (per-type mode)        |
-| `Xml2Doc_FileNameMode`        | `verbatim` or `clean`                   |
-| `Xml2Doc_RootNamespaceToTrim` | Trim prefix from display names          |
-| `Xml2Doc_CodeBlockLanguage`   | Fenced code language (default `csharp`) |
+```text
+Abstractions.Attributes.RequiredAttribute.md
+Engine.Execution.BatExecutionService.md
+```
 
-**Examples:**
+Do not enable `Xml2Doc_BasenameOnly` for a shared flat directory unless duplicate type names are impossible.
 
-Single file:
+Each invocation sees only its own compiler XML, so it cannot safely build an index containing the other projects. Keep `Xml2Doc_GenerateIndex=false` and maintain `docs/index.md` separately until multi-input aggregation is available.
+
+## Conditional generation
+
+```xml
+<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <Xml2Doc_Enabled>true</Xml2Doc_Enabled>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)' != 'Release'">
+  <Xml2Doc_Enabled>false</Xml2Doc_Enabled>
+</PropertyGroup>
+```
+
+Disable it for one command:
+
+```powershell
+dotnet build -p:Xml2Doc_Enabled=false
+```
+
+Inspect evaluated configuration:
+
+```powershell
+dotnet msbuild .\src\MyProject\MyProject.csproj `
+  -getProperty:Xml2Doc_Enabled `
+  -getProperty:Xml2Doc_OutputDir `
+  -getProperty:Xml2Doc_RootNamespaceToTrim `
+  -getProperty:Xml2Doc_GenerateIndex `
+  -getProperty:Xml2Doc_PruneStaleFiles `
+  -getProperty:Xml2Doc_ManifestIdentity `
+  -getProperty:Xml2Doc_LineEndings
+```
+
+## Single-file configuration
 
 ```xml
 <PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
   <Xml2Doc_SingleFile>true</Xml2Doc_SingleFile>
-  <Xml2Doc_OutputFile>$(ProjectDir)docs\api.md</Xml2Doc_OutputFile>
+  <Xml2Doc_OutputFile>$(MSBuildProjectDirectory)\docs\api.md</Xml2Doc_OutputFile>
   <Xml2Doc_FileNameMode>clean</Xml2Doc_FileNameMode>
   <Xml2Doc_RootNamespaceToTrim>MyCompany.MyProduct</Xml2Doc_RootNamespaceToTrim>
+  <Xml2Doc_LineEndings>lf</Xml2Doc_LineEndings>
 </PropertyGroup>
 ```
 
-Per-type:
+Do not enable stale pruning in single-file mode; validation will fail.
+
+## CLI quick start
+
+```powershell
+dotnet tool install --global Xml2Doc.Cli --version 2.0.2
+
+xml2doc `
+  --xml .\bin\Release\net9.0\MyLibrary.xml `
+  --out .\docs `
+  --file-names clean `
+  --rootns MyCompany.MyProduct `
+  --line-endings lf
+```
+
+Safe per-type pruning additionally requires:
+
+```powershell
+--prune-stale --manifest-id MyCompany.MyLibrary
+```
+
+Use `--single` when `--out` names one combined file. Pruning is unavailable in single-file mode.
+
+## Troubleshooting
+
+### Full namespaces remain in filenames
+
+Embedded newlines or indentation can prevent an exact prefix match in 2.0.2. Inspect the evaluated values:
+
+```powershell
+dotnet msbuild .\MyProject.csproj `
+  -getProperty:Xml2Doc_RootNamespaceToTrim `
+  -getProperty:Xml2Doc_TrimRootNamespaceInFileNames
+```
+
+### Shared projects overwrite `index.md`
+
+Set `Xml2Doc_GenerateIndex=false` for every independent project using the directory. A combined index requires a separate aggregation step until 2.3.0.
+
+### Removed source types leave Markdown behind
+
+Use per-type mode with pruning enabled and a stable manifest identity. The first run establishes ownership; files predating the manifest require one manual cleanup.
+
+### The task cannot load `Xml2Doc.Core`
+
+Use `Xml2Doc.MSBuild` 2.0.2 or later. Version 2.0.2 packages the task's runtime dependencies beside each task assembly.
+
+### Debug task selection or paths
+
+Temporarily enable:
 
 ```xml
-<PropertyGroup>
-  <Xml2Doc_SingleFile>false</Xml2Doc_SingleFile>
-  <Xml2Doc_OutputDir>$(ProjectDir)docs</Xml2Doc_OutputDir>
-  <Xml2Doc_FileNameMode>clean</Xml2Doc_FileNameMode>
-</PropertyGroup>
+<Xml2Doc_Dump>true</Xml2Doc_Dump>
+<Xml2Doc_LogChosenTask>true</Xml2Doc_LogChosenTask>
 ```
 
-**Visual Studio note:** The package includes a **`net472`** task so VS 2022 (MSBuild.exe host) can execute it.
-**`dotnet build`** uses the **`net8.0`** task host. Output Markdown is identical.
+## Roadmap
 
----
+See [TODO.md](TODO.md) and [the ADR index](docs/adr/README.md). Notable planned work includes:
 
-## 🧪 Tests & snapshots
+- `2.0.3`: portable output lifecycle state ([#77](https://github.com/mod-posh/xml2doc/issues/77)).
+- `2.1.0`: rendering extensibility.
+- `2.2.0`: diagnostics and pipeline improvements.
+- `2.3.0`: deterministic multi-project aggregation and a unified index.
 
-- Snapshot tests cover both output modes and representative APIs.
-- **Cross-TFM consistency test:** builds CLI for `net8.0` & `net9.0`, renders with each, and asserts identical output (normalized EOLs).
-- (Optional, Windows-only) Task build check for `net472` guards the P2P TFM mapping.
-
-**CI suggestion:**
-
-```yaml
-- run: dotnet build Xml2Doc.sln -c Release -m:1 -nr:false
-- run: dotnet test tests/Xml2Doc.Tests/Xml2Doc.Tests.csproj -c Release --no-build
-# On Windows, optionally:
-- if: runner.os == 'Windows'
-  run: dotnet build Xml2Doc/src/Xml2Doc.MSBuild/Xml2Doc.MSBuild.csproj -c Release -m:1 -v minimal
-```
-
----
-
-## 🧰 Troubleshooting
-
-- **`MSB3100: Properties syntax invalid (netX.Y)`**
-  A custom target is invoking the MSBuild task with `Properties="net8.0"` (missing `name=value`). Fix to:
-  `Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)"`.
-
-- **File locks during multi-target builds**
-  Build with `-m:1 -nr:false` to reduce handle contention:
-  `dotnet build Xml2Doc.sln -c Release -m:1 -nr:false`.
-
----
-
-## 📦 Maintenance & support
-
-We track current .NET (e.g., `net8.0`, `net9.0`) and maintain `netstandard2.0` for broad library reach.
-If you spot cross-TFM drift in output, please open an issue with a minimal XML sample plus expected vs actual Markdown.
+Report bugs and feature requests in the [GitHub issue tracker](https://github.com/mod-posh/xml2doc/issues).


### PR DESCRIPTION
## Summary

- add the proposed `2.0.3 — Portable Output Lifecycle State` milestone to the release sequence
- associate issue #77 with the milestone and document its completion criteria
- refresh the root `Xml2Doc.md` for the current 2.0.2 package line
- replace the outdated 1.1.0 MSBuild example
- document every supported csproj/Directory.Build property, default, valid values, and placement caveats
- add recommended single-project, shared-output, single-file, conditional, and troubleshooting examples
- document current lifecycle metadata, report handling, namespace whitespace behavior, and the 2.3.0 aggregation boundary

This documentation update tracks #77 but does not close it.