### PR TITLE
Render see langword values in generated Markdown

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -1169,14 +1169,14 @@ public sealed class MarkdownRenderer
                         text.Append(CrefToMarkdown(cref));
                     else
                     {
-                        var langword = (string?)e.Attribute("langword");
-                        if (!string.IsNullOrWhiteSpace(langword))
-                            text.Append($"`{langword}`");
+                        var href = (string?)e.Attribute("href");
+                        if (!string.IsNullOrWhiteSpace(href))
+                            text.Append($"[{e.Value}]({href})");
                         else
                         {
-                            var href = (string?)e.Attribute("href");
-                            text.Append(!string.IsNullOrWhiteSpace(href)
-                                ? $"[{e.Value}]({href})"
+                            var langword = (string?)e.Attribute("langword");
+                            text.Append(!string.IsNullOrWhiteSpace(langword)
+                                ? $"`{langword}`"
                                 : e.Value);
                         }
                     }

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -1169,10 +1169,16 @@ public sealed class MarkdownRenderer
                         text.Append(CrefToMarkdown(cref));
                     else
                     {
-                        var href = (string?)e.Attribute("href");
-                        text.Append(!string.IsNullOrWhiteSpace(href)
-                            ? $"[{e.Value}]({href})"
-                            : e.Value);
+                        var langword = (string?)e.Attribute("langword");
+                        if (!string.IsNullOrWhiteSpace(langword))
+                            text.Append($"`{langword}`");
+                        else
+                        {
+                            var href = (string?)e.Attribute("href");
+                            text.Append(!string.IsNullOrWhiteSpace(href)
+                                ? $"[{e.Value}]({href})"
+                                : e.Value);
+                        }
                     }
                     break;
                 case XElement e when e.Name.LocalName == "paramref":

--- a/Xml2Doc/tests/Xml2Doc.Tests/NormalizationTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/NormalizationTests.cs
@@ -21,35 +21,39 @@ public class NormalizationTests
                         Values may be <see langword="null"/>, <see langword="true"/>,
                         <see langword="false"/>, or accessed through <see langword="this"/>.
                         See <see cref="T:System.String"/> for an existing cref link.
+                        <see href="https://example.com" langword="ignored">Example</see> keeps href precedence.
                       </summary>
                     </member>
                   </members>
                 </doc>
                 """;
 
-        var tmpDir = Path.Combine(Path.GetTempPath(), "Xml2Doc.Tests", Path.GetRandomFileName());
+        var tmpRoot = Path.Join(Path.GetTempPath(), "Xml2Doc.Tests");
+        var tmpDir = Path.Join(tmpRoot, Path.GetRandomFileName());
         Directory.CreateDirectory(tmpDir);
 
         try
         {
-            var xmlPath = Path.Combine(tmpDir, "temp.xml");
+            var xmlPath = Path.Join(tmpDir, "temp.xml");
             await File.WriteAllTextAsync(xmlPath, xml, new UTF8Encoding(false));
 
             var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
             var renderer = new MarkdownRenderer(model, new RendererOptions(
                 FileNameMode: FileNameMode.CleanGenerics));
-            var outDir = Path.Combine(tmpDir, "out");
+            var outDir = Path.Join(tmpDir, "out");
 
             renderer.RenderToDirectory(outDir);
 
             var markdown = await File.ReadAllTextAsync(
-                Path.Combine(outDir, "Temp.Keywords.md"));
+                Path.Join(outDir, "Temp.Keywords.md"));
 
             markdown.ShouldContain("`null`");
             markdown.ShouldContain("`true`");
             markdown.ShouldContain("`false`");
             markdown.ShouldContain("`this`");
             markdown.ShouldContain("[String](System.String.md)");
+            markdown.ShouldContain("[Example](https://example.com)");
+            markdown.ShouldNotContain("`ignored`");
         }
         finally
         {

--- a/Xml2Doc/tests/Xml2Doc.Tests/NormalizationTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/NormalizationTests.cs
@@ -9,6 +9,56 @@ using Xunit;
 public class NormalizationTests
 {
     [Fact]
+    public async Task Normalize_RendersSeeLangwordAsInlineCode_WithoutChangingCrefLinks()
+    {
+        var xml = """
+                <?xml version="1.0"?>
+                <doc>
+                  <assembly><name>Temp</name></assembly>
+                  <members>
+                    <member name="T:Temp.Keywords">
+                      <summary>
+                        Values may be <see langword="null"/>, <see langword="true"/>,
+                        <see langword="false"/>, or accessed through <see langword="this"/>.
+                        See <see cref="T:System.String"/> for an existing cref link.
+                      </summary>
+                    </member>
+                  </members>
+                </doc>
+                """;
+
+        var tmpDir = Path.Combine(Path.GetTempPath(), "Xml2Doc.Tests", Path.GetRandomFileName());
+        Directory.CreateDirectory(tmpDir);
+
+        try
+        {
+            var xmlPath = Path.Combine(tmpDir, "temp.xml");
+            await File.WriteAllTextAsync(xmlPath, xml, new UTF8Encoding(false));
+
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+            var renderer = new MarkdownRenderer(model, new RendererOptions(
+                FileNameMode: FileNameMode.CleanGenerics));
+            var outDir = Path.Combine(tmpDir, "out");
+
+            renderer.RenderToDirectory(outDir);
+
+            var markdown = await File.ReadAllTextAsync(
+                Path.Combine(outDir, "Temp.Keywords.md"));
+
+            markdown.ShouldContain("`null`");
+            markdown.ShouldContain("`true`");
+            markdown.ShouldContain("`false`");
+            markdown.ShouldContain("`this`");
+            markdown.ShouldContain("[String](System.String.md)");
+        }
+        finally
+        {
+            if (Directory.Exists(tmpDir))
+                Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Normalize_PreservesParagraphs_TrimsIntraLine_ProtectsCodeBlocks()
     {
         // Build a synthetic XML doc file


### PR DESCRIPTION
## Summary

- recognize the `langword` attribute during inline `<see>` normalization
- render language keywords as inline Markdown code
- preserve existing `cref` and `href` handling precedence
- add regression coverage for `null`, `true`, `false`, and `this`
- assert existing `cref` links remain unchanged

## Validation

- `git diff --check` passes
- local .NET tests could not be executed because the current workspace does not provide the .NET SDK
- GitHub Actions will run the repository test suite for this draft PR

Closes #69