### PR TITLE
Resolve unique inheritdoc member signatures

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/InheritDocResolver.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/InheritDocResolver.cs
@@ -17,6 +17,10 @@ namespace Xml2Doc.Core
                 var key = cref!;
                 if (model.Members.TryGetValue(key, out var target))
                     return target.Element;
+
+                // An explicit target is authoritative. If it is not present in the
+                // loaded documentation, do not guess a different member by signature.
+                return null;
             }
             // Case 2: XML documentation does not record the implemented interface or base member.
             // Match the complete member suffix (including parameter types) only when one documented

--- a/Xml2Doc/src/Xml2Doc.Core/InheritDocResolver.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/InheritDocResolver.cs
@@ -18,29 +18,50 @@ namespace Xml2Doc.Core
                 if (model.Members.TryGetValue(key, out var target))
                     return target.Element;
             }
-            // Case 2: find matching member on base type or interfaces
-            // Member.Id is like: Namespace.Type.Method(System.String)
-            var id = member.Id;
-            var lastDot = id.LastIndexOf('.');
-            if (lastDot < 0) return null;
+            // Case 2: XML documentation does not record the implemented interface or base member.
+            // Match the complete member suffix (including parameter types) only when one documented
+            // candidate exists. Ambiguous matches deliberately remain unresolved.
+            var signature = GetMemberSignature(member.Id);
+            if (signature is null)
+                return null;
 
-            var typeId = id.Substring(0, lastDot); // Namespace.Type
-            var simple = id.Substring(lastDot + 1); // Method(...)
+            var candidates = model.Members.Values
+                .Where(candidate =>
+                    !ReferenceEquals(candidate, member) &&
+                    string.Equals(candidate.Kind, member.Kind, StringComparison.Ordinal) &&
+                    string.Equals(
+                        GetMemberSignature(candidate.Id),
+                        signature,
+                        StringComparison.Ordinal) &&
+                    HasInheritableContent(candidate.Element))
+                .Take(2)
+                .ToArray();
 
-            // Try base type of 'typeId' by trimming nested suffix segments
-            // (This is heuristic; full type system resolution would require reflection against binaries.)
-            // We'll attempt N-1 namespace/type prefix reductions as a cheap fallback.
-            var parts = typeId.Split('.');
-            for (int cut = parts.Length - 1; cut >= 1; cut--)
-            {
-                var candidateTypeId = string.Join(".", parts.Take(cut));
-                var candidateKey = $"M:{candidateTypeId}.{simple}";
-                if (model.Members.TryGetValue(candidateKey, out var target))
-                    return target.Element;
-            }
+            if (candidates.Length == 1)
+                return candidates[0].Element;
 
             return null;
         }
+
+        private static string? GetMemberSignature(string id)
+        {
+            var parameterList = id.IndexOf('(');
+            var memberHead = parameterList >= 0
+                ? id.Substring(0, parameterList)
+                : id;
+            var separator = memberHead.LastIndexOf('.');
+
+            return separator < 0
+                ? null
+                : id.Substring(separator + 1);
+        }
+
+        private static bool HasInheritableContent(XElement element) =>
+            element.Elements().Any(child =>
+                !string.Equals(
+                    child.Name.LocalName,
+                    "inheritdoc",
+                    StringComparison.Ordinal));
 
         public static void MergeInheritedContent(XElement into, XElement from)
         {
@@ -48,6 +69,7 @@ namespace Xml2Doc.Core
             CopyIfMissing(into, "summary", from);
             CopyIfMissing(into, "remarks", from);
             CopyIfMissing(into, "returns", from);
+            CopyIfMissing(into, "value", from);
 
             // Param-wise copy
             var intoParams = into.Elements("param")
@@ -59,18 +81,29 @@ namespace Xml2Doc.Core
                     into.Add(new XElement(p));
             }
 
+            var intoTypeParams = into.Elements("typeparam")
+                .ToDictionary(
+                    p => (string?)p.Attribute("name") ?? "",
+                    StringComparer.Ordinal);
+            foreach (var typeParam in from.Elements("typeparam"))
+            {
+                var name = (string?)typeParam.Attribute("name") ?? "";
+                if (!intoTypeParams.ContainsKey(name))
+                    into.Add(new XElement(typeParam));
+            }
+
             // Exceptions, seealso, examples – append if not present
             var fromExceptions = from.Elements("exception");
             if (!into.Elements("exception").Any() && fromExceptions.Any())
-                into.Add(fromExceptions);
+                into.Add(fromExceptions.Select(exception => new XElement(exception)));
 
             var fromSeeAlsos = from.Elements("seealso");
             if (!into.Elements("seealso").Any() && fromSeeAlsos.Any())
-                into.Add(fromSeeAlsos);
+                into.Add(fromSeeAlsos.Select(seeAlso => new XElement(seeAlso)));
 
             var fromExamples = from.Elements("example");
             if (!into.Elements("example").Any() && fromExamples.Any())
-                into.Add(fromExamples);
+                into.Add(fromExamples.Select(example => new XElement(example)));
         }
 
         private static void CopyIfMissing(XElement into, string name, XElement from)

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -1295,12 +1295,16 @@ public sealed class MarkdownRenderer
     /// <param name="asOverload">True to render as a bullet under an overload group; false for a full section.</param>
     private void RenderMember(XMember m, StringBuilder sb, bool asOverload)
     {
-        var inherit = m.Element.Element("inheritdoc");
+        // Resolve inheritance into a per-render copy. Mutating the source model would
+        // make an implementation rendered earlier eligible as a later inheritance
+        // candidate, causing output to depend on member ordering.
+        var memberElement = new XElement(m.Element);
+        var inherit = memberElement.Element("inheritdoc");
         if (inherit != null)
         {
             var target = InheritDocResolver.ResolveInheritedMember(_model, m);
             if (target != null)
-                InheritDocResolver.MergeInheritedContent(m.Element, target);
+                InheritDocResolver.MergeInheritedContent(memberElement, target);
         }
 
         sb.AppendLine($"<a id=\"{IdToAnchor(m.Id)}\"></a>");
@@ -1310,11 +1314,20 @@ public sealed class MarkdownRenderer
         else
             sb.AppendLine($"## {MemberHeader(m)}");
 
-        var ms = NormalizeXmlToMarkdown(m.Element.Element("summary"));
+        var ms = NormalizeXmlToMarkdown(memberElement.Element("summary"));
         if (!string.IsNullOrWhiteSpace(ms))
             sb.AppendLine(ms);
 
-        var typeParameters = m.Element.Elements("typeparam").ToList();
+        var remarks = NormalizeXmlToMarkdown(memberElement.Element("remarks"));
+        if (!string.IsNullOrWhiteSpace(remarks))
+        {
+            sb.AppendLine();
+            sb.AppendLine("**Remarks**");
+            sb.AppendLine();
+            sb.AppendLine(remarks);
+        }
+
+        var typeParameters = memberElement.Elements("typeparam").ToList();
         if (typeParameters.Count > 0)
         {
             sb.AppendLine();
@@ -1327,7 +1340,7 @@ public sealed class MarkdownRenderer
             }
         }
 
-        var ps = m.Element.Elements("param").ToList();
+        var ps = memberElement.Elements("param").ToList();
         if (ps.Count > 0)
         {
             sb.AppendLine();
@@ -1340,7 +1353,7 @@ public sealed class MarkdownRenderer
             }
         }
 
-        var ret = m.Element.Element("returns");
+        var ret = memberElement.Element("returns");
         if (ret != null)
         {
             sb.AppendLine();
@@ -1349,7 +1362,7 @@ public sealed class MarkdownRenderer
             sb.AppendLine(NormalizeXmlToMarkdown(ret));
         }
 
-        var value = m.Element.Element("value");
+        var value = memberElement.Element("value");
         if (value != null)
         {
             sb.AppendLine();
@@ -1358,7 +1371,7 @@ public sealed class MarkdownRenderer
             sb.AppendLine(NormalizeXmlToMarkdown(value));
         }
 
-        var exTags = m.Element.Elements("exception").ToList();
+        var exTags = memberElement.Elements("exception").ToList();
         if (exTags.Count > 0)
         {
             sb.AppendLine();
@@ -1372,7 +1385,7 @@ public sealed class MarkdownRenderer
             }
         }
 
-        var examples = m.Element.Elements("example").ToList();
+        var examples = memberElement.Elements("example").ToList();
         if (examples.Count > 0)
         {
             sb.AppendLine();
@@ -1388,7 +1401,7 @@ public sealed class MarkdownRenderer
             }
         }
 
-        var memberSeeAlsos = m.Element.Elements("seealso").ToList();
+        var memberSeeAlsos = memberElement.Elements("seealso").ToList();
         if (memberSeeAlsos.Count > 0)
         {
             sb.AppendLine();

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -1314,6 +1314,19 @@ public sealed class MarkdownRenderer
         if (!string.IsNullOrWhiteSpace(ms))
             sb.AppendLine(ms);
 
+        var typeParameters = m.Element.Elements("typeparam").ToList();
+        if (typeParameters.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("**Type parameters**");
+            foreach (var typeParameter in typeParameters)
+            {
+                var name = (string?)typeParameter.Attribute("name") ?? "";
+                var text = NormalizeXmlToMarkdown(typeParameter);
+                sb.AppendLine($"- `{name}` — {text}");
+            }
+        }
+
         var ps = m.Element.Elements("param").ToList();
         if (ps.Count > 0)
         {
@@ -1334,6 +1347,15 @@ public sealed class MarkdownRenderer
             sb.AppendLine("**Returns**");
             sb.AppendLine();
             sb.AppendLine(NormalizeXmlToMarkdown(ret));
+        }
+
+        var value = m.Element.Element("value");
+        if (value != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine("**Value**");
+            sb.AppendLine();
+            sb.AppendLine(NormalizeXmlToMarkdown(value));
         }
 
         var exTags = m.Element.Elements("exception").ToList();

--- a/Xml2Doc/tests/Xml2Doc.Tests/InheritDocResolverTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/InheritDocResolverTests.cs
@@ -32,6 +32,8 @@ public class InheritDocResolverTests
                     <member name="T:Temp.ExampleService"><summary>Implementation.</summary></member>
                     <member name="M:Temp.ExampleService.ExecuteAsync(Temp.Request)"><inheritdoc/></member>
                     <member name="M:Temp.ExampleService.ExecuteAsync(Temp.Request,System.Threading.CancellationToken)"><inheritdoc/></member>
+                    <member name="T:Temp.AnotherExampleService"><summary>Another implementation.</summary></member>
+                    <member name="M:Temp.AnotherExampleService.ExecuteAsync(Temp.Request)"><inheritdoc/></member>
 
                     <member name="T:Temp.ExplicitService"><summary>Explicit implementation.</summary></member>
                     <member name="M:Temp.ExplicitService.Run(Temp.Request)">
@@ -39,6 +41,14 @@ public class InheritDocResolverTests
                     </member>
                     <member name="M:Temp.IExplicitService.Run(Temp.Request)">
                       <summary>Runs through an explicit cref.</summary>
+                    </member>
+
+                    <member name="M:Temp.IOtherService.Remove(Temp.Request)">
+                      <summary>Unrelated removal guidance.</summary>
+                    </member>
+                    <member name="T:Temp.MissingExplicitService"><summary>Missing explicit target.</summary></member>
+                    <member name="M:Temp.MissingExplicitService.Remove(Temp.Request)">
+                      <inheritdoc cref="M:Temp.IMissingContract.Remove(Temp.Request)"/>
                     </member>
 
                     <member name="M:Temp.IGenericService.Map``1(``0)">
@@ -92,9 +102,18 @@ public class InheritDocResolverTests
             implementation.ShouldContain("Executes the cancellable request.");
             implementation.ShouldContain("The cancellation token.");
 
+            var anotherImplementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Temp.AnotherExampleService.md"));
+            anotherImplementation.ShouldContain("Executes the single-argument request.");
+            anotherImplementation.ShouldContain("Single-argument guidance.");
+
             var explicitImplementation = await File.ReadAllTextAsync(
                 Path.Join(outDir, "Temp.ExplicitService.md"));
             explicitImplementation.ShouldContain("Runs through an explicit cref.");
+
+            var missingExplicitImplementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Temp.MissingExplicitService.md"));
+            missingExplicitImplementation.ShouldNotContain("Unrelated removal guidance.");
 
             var genericImplementation = await File.ReadAllTextAsync(
                 Path.Join(outDir, "Temp.GenericService.md"));

--- a/Xml2Doc/tests/Xml2Doc.Tests/InheritDocResolverTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/InheritDocResolverTests.cs
@@ -1,0 +1,124 @@
+using Shouldly;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xml2Doc.Core;
+using Xunit;
+
+public class InheritDocResolverTests
+{
+    [Fact]
+    public async Task Render_ResolvesUniqueFullSignatureAndExplicitCref_ButNotAmbiguousMatches()
+    {
+        var xml = """
+                <?xml version="1.0"?>
+                <doc>
+                  <assembly><name>Temp</name></assembly>
+                  <members>
+                    <member name="T:Temp.IExampleService"><summary>Interface.</summary></member>
+                    <member name="M:Temp.IExampleService.ExecuteAsync(Temp.Request)">
+                      <summary>Executes the single-argument request.</summary>
+                      <param name="request">The request to execute.</param>
+                      <returns>The execution result.</returns>
+                      <remarks>Single-argument guidance.</remarks>
+                      <exception cref="T:System.InvalidOperationException">The request is invalid.</exception>
+                    </member>
+                    <member name="M:Temp.IExampleService.ExecuteAsync(Temp.Request,System.Threading.CancellationToken)">
+                      <summary>Executes the cancellable request.</summary>
+                      <param name="request">The cancellable request.</param>
+                      <param name="cancellationToken">The cancellation token.</param>
+                      <returns>The cancellable result.</returns>
+                    </member>
+                    <member name="T:Temp.ExampleService"><summary>Implementation.</summary></member>
+                    <member name="M:Temp.ExampleService.ExecuteAsync(Temp.Request)"><inheritdoc/></member>
+                    <member name="M:Temp.ExampleService.ExecuteAsync(Temp.Request,System.Threading.CancellationToken)"><inheritdoc/></member>
+
+                    <member name="T:Temp.ExplicitService"><summary>Explicit implementation.</summary></member>
+                    <member name="M:Temp.ExplicitService.Run(Temp.Request)">
+                      <inheritdoc cref="M:Temp.IExplicitService.Run(Temp.Request)"/>
+                    </member>
+                    <member name="M:Temp.IExplicitService.Run(Temp.Request)">
+                      <summary>Runs through an explicit cref.</summary>
+                    </member>
+
+                    <member name="M:Temp.IGenericService.Map``1(``0)">
+                      <summary>Maps a generic value.</summary>
+                      <typeparam name="T">The value type.</typeparam>
+                      <param name="value">The value to map.</param>
+                      <returns>The mapped value.</returns>
+                    </member>
+                    <member name="T:Temp.GenericService"><summary>Generic implementation.</summary></member>
+                    <member name="M:Temp.GenericService.Map``1(``0)"><inheritdoc/></member>
+
+                    <member name="P:Temp.IValueSource.Value">
+                      <summary>Gets the current value.</summary>
+                      <value>The current configured value.</value>
+                    </member>
+                    <member name="T:Temp.ValueSource"><summary>Value implementation.</summary></member>
+                    <member name="P:Temp.ValueSource.Value"><inheritdoc/></member>
+
+                    <member name="M:Temp.IFirst.Save(Temp.Request)"><summary>First save contract.</summary></member>
+                    <member name="M:Temp.ISecond.Save(Temp.Request)"><summary>Second save contract.</summary></member>
+                    <member name="T:Temp.AmbiguousService"><summary>Ambiguous implementation.</summary></member>
+                    <member name="M:Temp.AmbiguousService.Save(Temp.Request)"><inheritdoc/></member>
+                  </members>
+                </doc>
+                """;
+
+        var tmpRoot = Path.Join(Path.GetTempPath(), "Xml2Doc.Tests");
+        var tmpDir = Path.Join(tmpRoot, Path.GetRandomFileName());
+        Directory.CreateDirectory(tmpDir);
+
+        try
+        {
+            var xmlPath = Path.Join(tmpDir, "inheritdoc.xml");
+            await File.WriteAllTextAsync(xmlPath, xml, new UTF8Encoding(false));
+
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+            var renderer = new MarkdownRenderer(
+                model,
+                new RendererOptions(FileNameMode: FileNameMode.CleanGenerics));
+            var outDir = Path.Join(tmpDir, "out");
+
+            renderer.RenderToDirectory(outDir);
+
+            var implementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Temp.ExampleService.md"));
+            implementation.ShouldContain("Executes the single-argument request.");
+            implementation.ShouldContain("The request to execute.");
+            implementation.ShouldContain("The execution result.");
+            implementation.ShouldContain("Single-argument guidance.");
+            implementation.ShouldContain("The request is invalid.");
+            implementation.ShouldContain("Executes the cancellable request.");
+            implementation.ShouldContain("The cancellation token.");
+
+            var explicitImplementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Temp.ExplicitService.md"));
+            explicitImplementation.ShouldContain("Runs through an explicit cref.");
+
+            var genericImplementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Temp.GenericService.md"));
+            genericImplementation.ShouldContain("Maps a generic value.");
+            genericImplementation.ShouldContain("**Type parameters**");
+            genericImplementation.ShouldContain("- `T` — The value type.");
+            genericImplementation.ShouldContain("The value to map.");
+            genericImplementation.ShouldContain("The mapped value.");
+
+            var valueImplementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Temp.ValueSource.md"));
+            valueImplementation.ShouldContain("Gets the current value.");
+            valueImplementation.ShouldContain("**Value**");
+            valueImplementation.ShouldContain("The current configured value.");
+
+            var ambiguousImplementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Temp.AmbiguousService.md"));
+            ambiguousImplementation.ShouldNotContain("First save contract.");
+            ambiguousImplementation.ShouldNotContain("Second save contract.");
+        }
+        finally
+        {
+            if (Directory.Exists(tmpDir))
+                Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+}

--- a/Xml2Doc/tests/Xml2Doc.Tests/RenderSnapshots.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/RenderSnapshots.cs
@@ -192,9 +192,13 @@ public class RenderSnapshots
 
         var md = await File.ReadAllTextAsync(mdPath);
 
-        md = md.Replace("\r\n", "\n");
-        md = md.Replace("`", "");
-        md = Regex.Replace(md, @"\s+", " ");
+        var methodHeadings = string.Join(
+            " ",
+            md.Replace("\r\n", "\n")
+                .Split('\n')
+                .Where(line => line.StartsWith("## Method:", StringComparison.Ordinal)));
+        methodHeadings = methodHeadings.Replace("`", "");
+        methodHeadings = Regex.Replace(methodHeadings, @"\s+", " ");
 
         string xitem = @"(?:Xml2Doc\.Sample\.)?XItem";
         string ident = @"(?:\s+[A-Za-z_][A-Za-z0-9_]*)?";
@@ -208,12 +212,12 @@ public class RenderSnapshots
         var transformPattern =
             $@"(?i)Method:\s*Transform<\s*T1\s*,\s*T2\s*>\s*\(\s*List<\s*Dictionary<\s*T1\s*,\s*List<\s*T2\s*>\s*>\s*>\s*{ident}\s*\)";
 
-        Regex.IsMatch(md, flattenPattern).ShouldBeTrue("Expected Flatten(IEnumerable<IEnumerable<XItem>>) signature.");
-        Regex.IsMatch(md, indexPattern).ShouldBeTrue("Expected Index(Dictionary<string, List<XItem>>) signature.");
-        Regex.IsMatch(md, transformPattern).ShouldBeTrue("Expected Transform<T1,T2>(List<Dictionary<T1, List<T2>>>) signature.");
+        Regex.IsMatch(methodHeadings, flattenPattern).ShouldBeTrue("Expected Flatten(IEnumerable<IEnumerable<XItem>>) signature.");
+        Regex.IsMatch(methodHeadings, indexPattern).ShouldBeTrue("Expected Index(Dictionary<string, List<XItem>>) signature.");
+        Regex.IsMatch(methodHeadings, transformPattern).ShouldBeTrue("Expected Transform<T1,T2>(List<Dictionary<T1, List<T2>>>) signature.");
 
-        md.ShouldNotContain("})");
-        md.ShouldNotContain("Int32)");
+        methodHeadings.ShouldNotContain("})");
+        methodHeadings.ShouldNotContain("Int32)");
     }
 
     private static string Normalize(string s) =>

--- a/Xml2Doc/tests/Xml2Doc.Tests/__snapshots__/PerType_CleanNames/Xml2Doc.Sample.GenericPlayground.verified.md
+++ b/Xml2Doc/tests/Xml2Doc.Tests/__snapshots__/PerType_CleanNames/Xml2Doc.Sample.GenericPlayground.verified.md
@@ -6,9 +6,17 @@ Generic playground for exercising nested generic parameter lists.
 ## Method: Flatten(IEnumerable<IEnumerable<XItem>>)
 Flattens a nested sequence.
 
+**Remarks**
+
+This used to surface a stray brace in signatures like `IEnumerable{IEnumerable{XItem}}`. The renderer must output `IEnumerable<IEnumerable<XItem>>` (no extra `}`). See also [Flatten(System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<Xml2Doc.Sample.XItem>>)](Xml2Doc.Sample.GenericPlayground.md#xml2doc.sample.genericplayground.flatten(system.collections.generic.ienumerable[system.collections.generic.ienumerable[xml2doc.sample.xitem]])).
+
 <a id="xml2doc.sample.genericplayground.index(system.collections.generic.dictionary[string,system.collections.generic.list[xml2doc.sample.xitem]])"></a>
 ## Method: Index(Dictionary<string, List<XItem>>)
 Builds an index over a nested structure.
+
+**Remarks**
+
+Signature includes `Dictionary{string, List{XItem}}` which must render as `Dictionary<string, List<XItem>>` (no stray braces).
 
 **Parameters**
 - `map` — Nested map to index.


### PR DESCRIPTION
## Summary

- preserve exact explicit `inheritdoc cref` resolution
- replace namespace-prefix guessing with full member-signature matching
- resolve bare `inheritdoc` only when exactly one documented candidate exists
- match overloads by complete parameter signature
- leave ambiguous interface contracts unresolved instead of selecting arbitrary documentation
- copy inherited `summary`, `remarks`, `param`, `returns`, `value`, `typeparam`, `exception`, `seealso`, and `example` content
- render type-parameter and property-value documentation

## Regression coverage

- overloaded implicit interface-style members
- explicit `inheritdoc cref`
- inherited parameters, returns, remarks, and exceptions
- generic method type-parameter documentation
- property value documentation
- ambiguous same-signature contracts

## Scope note

This is the first #68 slice. It improves resolution when the inherited member is present in the loaded XML model. The reported BAT implementation/interface case spans project XML files; referenced XML loading still needs to be evaluated before #68 can close.

## Validation

- `git diff --check` passes
- local .NET tests could not run because this workspace does not provide the .NET SDK
- GitHub Actions will validate the draft