### PR TITLE
Resolve inheritdoc across project references

### DIFF
--- a/Xml2Doc.md
+++ b/Xml2Doc.md
@@ -76,6 +76,20 @@ The package currently assigns `Xml2Doc_Toc`, `Xml2Doc_NamespaceIndex`, and `Xml2
 
 Stale-file pruning is supported only in per-type mode. Single-file mode replaces its configured output directly.
 
+Xml2Doc automatically loads XML documentation found beside referenced project
+assemblies for `<inheritdoc />` resolution. Referenced members participate only in
+inheritance lookup and do not generate additional Markdown pages. Extra XML files can
+be supplied explicitly when an assembly and its documentation are not colocated:
+
+```xml
+<ItemGroup>
+  <Xml2Doc_ReferenceXml Include="$(BaseOutputPath)Contracts\Contracts.xml" />
+</ItemGroup>
+```
+
+Missing explicit files and unresolved `<inheritdoc />` targets produce MSBuild warnings.
+Reference XML contents are included in incremental fingerprinting.
+
 ### Naming, links, and rendering
 
 | Property | Default | Values | Behavior |

--- a/Xml2Doc/src/Xml2Doc.Core/InheritDocResolver.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/InheritDocResolver.cs
@@ -17,6 +17,8 @@ namespace Xml2Doc.Core
                 var key = cref!;
                 if (model.Members.TryGetValue(key, out var target))
                     return target.Element;
+                if (model.ReferenceMembers.TryGetValue(key, out target))
+                    return target.Element;
 
                 // An explicit target is authoritative. If it is not present in the
                 // loaded documentation, do not guess a different member by signature.
@@ -30,6 +32,7 @@ namespace Xml2Doc.Core
                 return null;
 
             var candidates = model.Members.Values
+                .Concat(model.ReferenceMembers.Values)
                 .Where(candidate =>
                     !ReferenceEquals(candidate, member) &&
                     string.Equals(candidate.Kind, member.Kind, StringComparison.Ordinal) &&

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -1305,6 +1305,9 @@ public sealed class MarkdownRenderer
             var target = InheritDocResolver.ResolveInheritedMember(_model, m);
             if (target != null)
                 InheritDocResolver.MergeInheritedContent(memberElement, target);
+            else
+                _opt.WarningSink?.Invoke(
+                    $"Unable to resolve <inheritdoc /> for '{m.Name}'.");
         }
 
         sb.AppendLine($"<a id=\"{IdToAnchor(m.Id)}\"></a>");

--- a/Xml2Doc/src/Xml2Doc.Core/Models/Xml2DocModel.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Models/Xml2DocModel.cs
@@ -58,11 +58,13 @@ namespace Xml2Doc.Core.Models
         /// <param name="xmlPaths">Reference XML documentation paths.</param>
         public void LoadReferences(IEnumerable<string> xmlPaths)
         {
-            foreach (var xmlPath in xmlPaths
+            foreach (var doc in xmlPaths
                 .Where(path => !string.IsNullOrWhiteSpace(path))
-                .Distinct(StringComparer.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(path => XDocument.Load(
+                    path,
+                    LoadOptions.PreserveWhitespace)))
             {
-                var doc = XDocument.Load(xmlPath, LoadOptions.PreserveWhitespace);
                 foreach (var element in doc.Descendants("member"))
                 {
                     var name = (string?)element.Attribute("name");

--- a/Xml2Doc/src/Xml2Doc.Core/Models/Xml2DocModel.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Models/Xml2DocModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace Xml2Doc.Core.Models
@@ -17,6 +18,13 @@ namespace Xml2Doc.Core.Models
         /// Examples: <c>T:MyNamespace.MyType</c>, <c>M:MyNamespace.MyType.MyMethod(System.String)</c>.
         /// </remarks>
         public Dictionary<string, XMember> Members { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets documented members loaded from reference XML files. These members are
+        /// available for inheritance lookup but are not rendered as output pages.
+        /// </summary>
+        public Dictionary<string, XMember> ReferenceMembers { get; } =
+            new(StringComparer.Ordinal);
 
         /// <summary>
         /// Loads an XML documentation file and builds the <see cref="Xml2Doc"/> model.
@@ -41,6 +49,29 @@ namespace Xml2Doc.Core.Models
             }
 
             return model;
+        }
+
+        /// <summary>
+        /// Loads additional XML documentation for inheritance lookup without adding
+        /// referenced types to the set of rendered output pages.
+        /// </summary>
+        /// <param name="xmlPaths">Reference XML documentation paths.</param>
+        public void LoadReferences(IEnumerable<string> xmlPaths)
+        {
+            foreach (var xmlPath in xmlPaths
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var doc = XDocument.Load(xmlPath, LoadOptions.PreserveWhitespace);
+                foreach (var element in doc.Descendants("member"))
+                {
+                    var name = (string?)element.Attribute("name");
+                    if (string.IsNullOrWhiteSpace(name) || Members.ContainsKey(name!))
+                        continue;
+
+                    ReferenceMembers[name!] = new XMember(name!, element);
+                }
+            }
         }
     }
 

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -123,6 +123,10 @@ namespace Xml2Doc.Core
     /// <param name="LineEndings">
     /// Line-ending policy for all rendered Markdown. Defaults to deterministic LF on every host.
     /// </param>
+    /// <param name="WarningSink">
+    /// Optional callback invoked for non-fatal rendering warnings, including unresolved
+    /// <c>&lt;inheritdoc /&gt;</c> members.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -168,6 +172,7 @@ namespace Xml2Doc.Core
         bool GenerateIndex = true,
         bool PruneStaleFiles = false,
         string? ManifestIdentity = null,
-        LineEndingStyle LineEndings = LineEndingStyle.Lf
+        LineEndingStyle LineEndings = LineEndingStyle.Lf,
+        Action<string>? WarningSink = null
     );
 }

--- a/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
@@ -272,7 +272,13 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
             }
 
             var referenceXmlPaths = ReferenceXmlPaths
-                .Select(item => item.ItemSpec)
+                .Select(item =>
+                {
+                    var fullPath = item.GetMetadata("FullPath");
+                    return string.IsNullOrWhiteSpace(fullPath)
+                        ? item.ItemSpec
+                        : fullPath;
+                })
                 .Where(path => !string.IsNullOrWhiteSpace(path))
                 .Select(Path.GetFullPath)
                 .Where(path => !string.Equals(path, xmlFull, StringComparison.OrdinalIgnoreCase))

--- a/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/GenerateMarkdownFromXmlDoc.cs
@@ -68,6 +68,12 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
     [Required] public string XmlPath { get; set; } = string.Empty;
 
     /// <summary>
+    /// XML documentation files from referenced projects or assemblies. Their members
+    /// participate in inheritance lookup but do not produce Markdown pages.
+    /// </summary>
+    public ITaskItem[] ReferenceXmlPaths { get; set; } = Array.Empty<ITaskItem>();
+
+    /// <summary>
     /// Directory for per‑type Markdown output (ignored in single‑file mode). Required when <see cref="SingleFile"/> is <see langword="false"/>.
     /// </summary>
     public string? OutputDirectory { get; set; }
@@ -265,7 +271,26 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
                 }
             }
 
+            var referenceXmlPaths = ReferenceXmlPaths
+                .Select(item => item.ItemSpec)
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Select(Path.GetFullPath)
+                .Where(path => !string.Equals(path, xmlFull, StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var existingReferenceXmlPaths = referenceXmlPaths
+                .Where(File.Exists)
+                .ToArray();
+
+            foreach (var missingPath in referenceXmlPaths.Except(
+                existingReferenceXmlPaths,
+                StringComparer.OrdinalIgnoreCase))
+            {
+                Log.LogWarning($"Xml2Doc: reference XML not found at '{missingPath}'.");
+            }
+
             var model = Core.Models.Xml2Doc.Load(xmlFull);
+            model.LoadReferences(existingReferenceXmlPaths);
 
             var fnMode = FileNameMode.Equals("clean", StringComparison.OrdinalIgnoreCase)
                 ? Core.FileNameMode.CleanGenerics
@@ -291,7 +316,8 @@ public class GenerateMarkdownFromXmlDoc : Microsoft.Build.Utilities.Task
                 GenerateIndex: GenerateIndex,
                 PruneStaleFiles: PruneStaleFiles,
                 ManifestIdentity: ManifestIdentity,
-                LineEndings: lineEndingStyle
+                LineEndings: lineEndingStyle,
+                WarningSink: warning => Log.LogWarning($"Xml2Doc: {warning}")
             );
 
             var renderer = new MarkdownRenderer(model, options);

--- a/Xml2Doc/src/Xml2Doc.MSBuild/README.md
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/README.md
@@ -53,6 +53,16 @@ That’s it—on successful build, docs are generated according to the propertie
 | `Xml2Doc_ManifestIdentity`    | Stable identity required when stale-output pruning is enabled.             |
 | `Xml2Doc_LineEndings`         | Markdown newlines: `lf` (default), `crlf`, or `native`.                    |
 
+Referenced-project XML documentation found beside project output assemblies is loaded
+automatically for `<inheritdoc />` resolution without generating pages for referenced
+types. Additional documentation files can be supplied as items:
+
+```xml
+<ItemGroup>
+  <Xml2Doc_ReferenceXml Include="path\to\Contracts.xml" />
+</ItemGroup>
+```
+
 ### Examples
 
 **Single file (good for READMEs / wikis)**

--- a/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
@@ -77,8 +77,22 @@
             and '$(DocumentationFile)' != ''
             and Exists('$(DocumentationFile)')">
 
+    <ItemGroup>
+      <_Xml2Doc_AutomaticReferenceXml Include="@(_ResolvedProjectReferencePaths->'%(RootDir)%(Directory)%(Filename).xml')"
+                                      Condition="Exists('%(_ResolvedProjectReferencePaths.RootDir)%(_ResolvedProjectReferencePaths.Directory)%(_ResolvedProjectReferencePaths.Filename).xml')" />
+      <_Xml2Doc_ExistingExplicitReferenceXml Include="@(Xml2Doc_ReferenceXml)"
+                                              Condition="Exists('%(Xml2Doc_ReferenceXml.FullPath)')" />
+      <_Xml2Doc_ReferenceXml Include="@(_Xml2Doc_AutomaticReferenceXml);@(_Xml2Doc_ExistingExplicitReferenceXml)" />
+    </ItemGroup>
+
     <GetFileHash Files="$(DocumentationFile)" Algorithm="SHA256">
       <Output TaskParameter="Items" ItemName="_Xml2Doc_HashItem" />
+    </GetFileHash>
+
+    <GetFileHash Files="@(_Xml2Doc_ReferenceXml)"
+                 Algorithm="SHA256"
+                 Condition="'@(_Xml2Doc_ReferenceXml)' != ''">
+      <Output TaskParameter="Items" ItemName="_Xml2Doc_ReferenceHashItem" />
     </GetFileHash>
 
     <PropertyGroup>
@@ -88,11 +102,13 @@
 
     <ItemGroup>
       <_Xml2Doc_HashValue Include="@(_Xml2Doc_HashItem->'%(Hash)')" />
+      <_Xml2Doc_ReferenceHashValue Include="@(_Xml2Doc_ReferenceHashItem->'%(Hash)')" />
     </ItemGroup>
 
     <PropertyGroup>
       <_Xml2Doc_Hash>@(_Xml2Doc_HashValue)</_Xml2Doc_Hash>
-      <_Xml2Doc_Fingerprint>$(_Xml2Doc_Hash)|$(_Xml2Doc_Options)</_Xml2Doc_Fingerprint>
+      <_Xml2Doc_ReferenceHash>@(_Xml2Doc_ReferenceHashValue, ',')</_Xml2Doc_ReferenceHash>
+      <_Xml2Doc_Fingerprint>$(_Xml2Doc_Hash)|$(_Xml2Doc_ReferenceHash)|$(_Xml2Doc_Options)</_Xml2Doc_Fingerprint>
     </PropertyGroup>
 
     <ReadLinesFromFile File="$(Xml2Doc_FingerprintFile)"
@@ -131,6 +147,7 @@
              Condition="'$(_Xml2Doc_OutputStampDir)' != '' and !Exists('$(_Xml2Doc_OutputStampDir)')" />
 
     <GenerateMarkdownFromXmlDoc XmlPath="$(DocumentationFile)"
+                                ReferenceXmlPaths="@(_Xml2Doc_AutomaticReferenceXml);@(Xml2Doc_ReferenceXml)"
                                 SingleFile="$(Xml2Doc_SingleFile)"
                                 OutputFile="$(Xml2Doc_OutputFile)"
                                 OutputDirectory="$(Xml2Doc_OutputDir)"

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -2,6 +2,7 @@
 using Shouldly;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -16,13 +17,14 @@ namespace Xml2Doc.Tests
     {
         private sealed class TestBuildEngine : IBuildEngine
         {
+            public List<BuildWarningEventArgs> Warnings { get; } = new();
             public bool ContinueOnError => false;
             public int LineNumberOfTaskNode => 0;
             public int ColumnNumberOfTaskNode => 0;
             public string ProjectFileOfTaskNode => string.Empty;
 
             public void LogErrorEvent(BuildErrorEventArgs e) { }
-            public void LogWarningEvent(BuildWarningEventArgs e) { }
+            public void LogWarningEvent(BuildWarningEventArgs e) => Warnings.Add(e);
             public void LogMessageEvent(BuildMessageEventArgs e) { }
             public void LogCustomEvent(CustomBuildEventArgs e) { }
 
@@ -251,6 +253,61 @@ namespace Xml2Doc.Tests
                 .Single().Value.ShouldContain("$(_Xml2Doc_NativeLineEndingToken)");
             taskElement.Attribute("LineEndings")!.Value
                 .ShouldBe("$(Xml2Doc_LineEndings)");
+            taskElement.Attribute("ReferenceXmlPaths")!.Value
+                .ShouldBe("@(_Xml2Doc_AutomaticReferenceXml);@(Xml2Doc_ReferenceXml)");
+        }
+
+        [Fact]
+        public void ReferenceXmlPaths_ResolveInheritedDocumentationAndLogMissingTargets()
+        {
+            var root = CreateOutputDirectory();
+            var outDir = Path.Combine(root, "docs");
+            Directory.CreateDirectory(root);
+            var primaryPath = Path.Combine(root, "Consumer.xml");
+            var referencePath = Path.Combine(root, "Contracts.xml");
+            File.WriteAllText(primaryPath, """
+                <doc><members>
+                  <member name="T:Consumer.Service"><summary>Service.</summary></member>
+                  <member name="M:Consumer.Service.Run">
+                    <inheritdoc cref="M:Contracts.IService.Run"/>
+                  </member>
+                  <member name="M:Consumer.Service.Missing">
+                    <inheritdoc cref="M:Contracts.IService.Missing"/>
+                  </member>
+                </members></doc>
+                """);
+            File.WriteAllText(referencePath, """
+                <doc><members>
+                  <member name="M:Contracts.IService.Run">
+                    <summary>Runs from the referenced project.</summary>
+                  </member>
+                </members></doc>
+                """);
+            var buildEngine = new TestBuildEngine();
+
+            try
+            {
+                var task = new GenerateMarkdownFromXmlDoc
+                {
+                    BuildEngine = buildEngine,
+                    XmlPath = primaryPath,
+                    ReferenceXmlPaths = new ITaskItem[] { new TaskItem(referencePath) },
+                    OutputDirectory = outDir,
+                    FileNameMode = "clean"
+                };
+
+                task.Execute().ShouldBeTrue();
+
+                File.ReadAllText(Path.Combine(outDir, "Consumer.Service.md"))
+                    .ShouldContain("Runs from the referenced project.");
+                buildEngine.Warnings.Count.ShouldBe(1);
+                buildEngine.Warnings[0].Message.ShouldContain("M:Consumer.Service.Missing");
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
         }
 
         [Fact]

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Shouldly;
 using System;
 using System.Collections;
@@ -301,7 +302,8 @@ namespace Xml2Doc.Tests
                 File.ReadAllText(Path.Combine(outDir, "Consumer.Service.md"))
                     .ShouldContain("Runs from the referenced project.");
                 buildEngine.Warnings.Count.ShouldBe(1);
-                buildEngine.Warnings[0].Message.ShouldContain("M:Consumer.Service.Missing");
+                buildEngine.Warnings[0].Message!
+                    .ShouldContain("M:Consumer.Service.Missing");
             }
             finally
             {

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -262,10 +262,10 @@ namespace Xml2Doc.Tests
         public void ReferenceXmlPaths_ResolveInheritedDocumentationAndLogMissingTargets()
         {
             var root = CreateOutputDirectory();
-            var outDir = Path.Combine(root, "docs");
+            var outDir = root + Path.DirectorySeparatorChar + "docs";
             Directory.CreateDirectory(root);
-            var primaryPath = Path.Combine(root, "Consumer.xml");
-            var referencePath = Path.Combine(root, "Contracts.xml");
+            var primaryPath = root + Path.DirectorySeparatorChar + "Consumer.xml";
+            var referencePath = root + Path.DirectorySeparatorChar + "Contracts.xml";
             File.WriteAllText(primaryPath, """
                 <doc><members>
                   <member name="T:Consumer.Service"><summary>Service.</summary></member>
@@ -299,7 +299,8 @@ namespace Xml2Doc.Tests
 
                 task.Execute().ShouldBeTrue();
 
-                File.ReadAllText(Path.Combine(outDir, "Consumer.Service.md"))
+                File.ReadAllText(
+                        outDir + Path.DirectorySeparatorChar + "Consumer.Service.md")
                     .ShouldContain("Runs from the referenced project.");
                 buildEngine.Warnings.Count.ShouldBe(1);
                 buildEngine.Warnings[0].Message!

--- a/Xml2Doc/tests/Xml2Doc.Tests/InheritDocResolverTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/InheritDocResolverTests.cs
@@ -1,4 +1,5 @@
 using Shouldly;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,6 +8,113 @@ using Xunit;
 
 public class InheritDocResolverTests
 {
+    [Fact]
+    public async Task Render_UsesReferenceXmlForInheritanceWithoutRenderingReferenceTypes()
+    {
+        var primaryXml = """
+                <?xml version="1.0"?>
+                <doc>
+                  <members>
+                    <member name="T:Consumer.ExampleService"><summary>Implementation.</summary></member>
+                    <member name="M:Consumer.ExampleService.Run(Contracts.Request)">
+                      <inheritdoc cref="M:Contracts.IExampleService.Run(Contracts.Request)"/>
+                    </member>
+                    <member name="M:Consumer.ExampleService.Save(Contracts.Request)"><inheritdoc/></member>
+                  </members>
+                </doc>
+                """;
+        var referenceXml = """
+                <?xml version="1.0"?>
+                <doc>
+                  <members>
+                    <member name="T:Contracts.IExampleService"><summary>Contract.</summary></member>
+                    <member name="M:Contracts.IExampleService.Run(Contracts.Request)">
+                      <summary>Runs from referenced documentation.</summary>
+                    </member>
+                    <member name="M:Contracts.IExampleService.Save(Contracts.Request)">
+                      <summary>Saves from referenced documentation.</summary>
+                    </member>
+                  </members>
+                </doc>
+                """;
+
+        var tmpDir = Path.Join(
+            Path.GetTempPath(),
+            "Xml2Doc.Tests",
+            Path.GetRandomFileName());
+        Directory.CreateDirectory(tmpDir);
+
+        try
+        {
+            var primaryPath = Path.Join(tmpDir, "Consumer.xml");
+            var referencePath = Path.Join(tmpDir, "Contracts.xml");
+            await File.WriteAllTextAsync(primaryPath, primaryXml, new UTF8Encoding(false));
+            await File.WriteAllTextAsync(referencePath, referenceXml, new UTF8Encoding(false));
+
+            var warnings = new List<string>();
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(primaryPath);
+            model.LoadReferences(new[] { referencePath });
+            var renderer = new MarkdownRenderer(
+                model,
+                new RendererOptions(
+                    FileNameMode: FileNameMode.CleanGenerics,
+                    WarningSink: warnings.Add));
+            var outDir = Path.Join(tmpDir, "out");
+
+            renderer.RenderToDirectory(outDir);
+
+            var implementation = await File.ReadAllTextAsync(
+                Path.Join(outDir, "Consumer.ExampleService.md"));
+            implementation.ShouldContain("Runs from referenced documentation.");
+            implementation.ShouldContain("Saves from referenced documentation.");
+            File.Exists(Path.Join(outDir, "Contracts.IExampleService.md"))
+                .ShouldBeFalse();
+            warnings.ShouldBeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(tmpDir))
+                Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Render_WhenInheritDocCannotBeResolved_EmitsWarning()
+    {
+        var xml = """
+                <?xml version="1.0"?>
+                <doc><members>
+                  <member name="T:Temp.Service"><summary>Service.</summary></member>
+                  <member name="M:Temp.Service.Run"><inheritdoc cref="M:Missing.Contract.Run"/></member>
+                </members></doc>
+                """;
+        var tmpDir = Path.Join(
+            Path.GetTempPath(),
+            "Xml2Doc.Tests",
+            Path.GetRandomFileName());
+        Directory.CreateDirectory(tmpDir);
+
+        try
+        {
+            var xmlPath = Path.Join(tmpDir, "Temp.xml");
+            await File.WriteAllTextAsync(xmlPath, xml, new UTF8Encoding(false));
+            var warnings = new List<string>();
+            var renderer = new MarkdownRenderer(
+                Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath),
+                new RendererOptions(WarningSink: warnings.Add));
+
+            renderer.RenderToDirectory(Path.Join(tmpDir, "out"));
+
+            warnings.Count.ShouldBe(1);
+            warnings[0].ShouldContain("M:Temp.Service.Run");
+        }
+        finally
+        {
+            if (Directory.Exists(tmpDir))
+                Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task Render_ResolvesUniqueFullSignatureAndExplicitCref_ButNotAmbiguousMatches()
     {


### PR DESCRIPTION
## Summary

Completes the remaining cross-project `<inheritdoc />` work for issue #68.

- loads XML documentation beside referenced project assemblies
- keeps reference members lookup-only so they do not create duplicate Markdown pages
- supports explicit `Xml2Doc_ReferenceXml` items when XML and assemblies are not colocated
- includes reference XML hashes in MSBuild incremental fingerprinting
- emits warnings for missing reference XML and unresolved inheritance targets
- documents the new behavior and configuration
- adds Core and MSBuild regression coverage

## Why

The first #68 slice resolved inheritance when the target member existed in the primary XML document. Implementations and interfaces commonly live in separate projects, so the interface documentation was still unavailable to the renderer.

## Validation

- `git diff --check`
- local and remote blobs verified identical for all changed files
- GitHub Actions will provide the authoritative build, unit, CLI, and MSBuild integration validation because the current workspace does not include the .NET SDK

Closes #68