### PR TITLE
Make stale-output manifests portable across checkouts

### DIFF
--- a/Xml2Doc.md
+++ b/Xml2Doc.md
@@ -13,7 +13,8 @@ The current stable package line is `2.0.2`:
 - Markdown uses LF on every platform by default.
 - Multiple projects can safely share an output directory when they have distinct manifest identities and disable their project-owned indexes.
 - Unified multi-project index aggregation is planned for `2.3.0`. Until then, maintain or generate the repository index separately.
-- Ownership manifests are local workspace state in 2.0.2. Portable manifests are tracked by [issue #77](https://github.com/mod-posh/xml2doc/issues/77) for the proposed `2.0.3` milestone.
+- Portable ownership manifests are implemented for the upcoming `2.0.3` release and migrate safe
+  2.0.x manifests when they are next saved.
 
 ## Supported frameworks
 
@@ -124,7 +125,10 @@ Lifecycle metadata is stored under:
 └── transactions/
 ```
 
-The transactions directory is normally empty after a successful build. Temporary child directories stage stale files while the manifest is replaced and are then removed. In 2.0.2, ignore `.xml2doc` because its manifests record an absolute output root and are not portable between checkout paths; see issue #77.
+The transactions directory is normally empty after a successful build. Temporary child directories
+stage stale files while the manifest is replaced and are then removed. Starting in 2.0.3, commit
+`.xml2doc/manifests` when generated Markdown is versioned so a clean checkout retains ownership
+history. Always ignore `.xml2doc/transactions`; it is local, best-effort staging state.
 
 ### Reports and diagnostics
 
@@ -137,11 +141,11 @@ The transactions directory is normally empty after a successful build. Temporary
 | `Xml2Doc_LogChosenTask` | `false` | `true`, `false` | Logs the selected task TFM and assembly path. |
 | `Xml2Doc_Diff` | `false` | Reserved | Has no effect in 2.0.2. |
 
-Reports and local lifecycle state may be ignored:
+Reports and transaction staging may be ignored:
 
 ```gitignore
 docs/xml2doc-report*.json
-docs/.xml2doc/
+docs/.xml2doc/transactions/
 ```
 
 ### Incremental-build controls

--- a/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifest.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifest.cs
@@ -7,7 +7,9 @@ namespace Xml2Doc.Core.OutputLifecycle
     /// </summary>
     /// <param name="SchemaVersion">The manifest schema version.</param>
     /// <param name="Identity">The exact opaque identity of the owning invocation.</param>
-    /// <param name="OutputRoot">The canonical root directory containing the generated files.</param>
+    /// <param name="OutputRoot">
+    /// The portable output-root marker. Version 1 manifests may contain a legacy absolute path.
+    /// </param>
     /// <param name="Files">
     /// The normalized, output-root-relative paths owned by the invocation.
     /// </param>
@@ -20,6 +22,11 @@ namespace Xml2Doc.Core.OutputLifecycle
         /// <summary>
         /// Gets the schema version supported by the current implementation.
         /// </summary>
-        public const int CurrentSchemaVersion = 1;
+        public const int CurrentSchemaVersion = 2;
+
+        /// <summary>
+        /// Identifies the current output root without persisting a machine-specific path.
+        /// </summary>
+        public const string PortableOutputRoot = ".";
     }
 }

--- a/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestPlanner.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestPlanner.cs
@@ -79,11 +79,11 @@ namespace Xml2Doc.Core.OutputLifecycle
                     Array.Empty<string>());
             }
 
-            ValidateManifest(canonicalOutputRoot, previousManifest);
+            ValidateManifest(previousManifest);
 
             var previouslyOwnedFiles = ValidateAndNormalizeEntries(
                 canonicalOutputRoot,
-                previousManifest.Files,
+                NormalizeManifestSeparators(previousManifest),
                 entry => new InvalidDataException(
                     $"The manifest file entry '{entry}' is invalid."),
                 duplicate => new InvalidDataException(
@@ -103,14 +103,28 @@ namespace Xml2Doc.Core.OutputLifecycle
                 filesToDelete);
         }
 
-        private static void ValidateManifest(
-            string canonicalOutputRoot,
+        private static IReadOnlyList<string> NormalizeManifestSeparators(
             OutputManifest manifest)
         {
-            if (manifest.SchemaVersion != OutputManifest.CurrentSchemaVersion)
+            if (manifest.SchemaVersion != 1 ||
+                manifest.OutputRoot.IndexOf('\\') < 0)
+            {
+                return manifest.Files;
+            }
+
+            return manifest.Files
+                .Select(path => path.Replace('\\', Path.DirectorySeparatorChar))
+                .ToArray();
+        }
+
+        private static void ValidateManifest(OutputManifest manifest)
+        {
+            if (manifest.SchemaVersion != 1 &&
+                manifest.SchemaVersion != OutputManifest.CurrentSchemaVersion)
             {
                 throw new InvalidDataException(
-                    $"Manifest schema version {manifest.SchemaVersion} is not supported.");
+                    $"Manifest schema version {manifest.SchemaVersion} is not supported. " +
+                    $"Regenerate it with a version of Xml2Doc that supports schema {OutputManifest.CurrentSchemaVersion}.");
             }
 
             if (string.IsNullOrWhiteSpace(manifest.OutputRoot))
@@ -119,29 +133,14 @@ namespace Xml2Doc.Core.OutputLifecycle
                     "The manifest output root is missing.");
             }
 
-            string manifestOutputRoot;
-
-            try
-            {
-                manifestOutputRoot = NormalizeRootPath(manifest.OutputRoot);
-            }
-            catch (Exception exception) when (
-                exception is ArgumentException ||
-                exception is NotSupportedException ||
-                exception is PathTooLongException)
+            if (manifest.SchemaVersion == OutputManifest.CurrentSchemaVersion &&
+                !string.Equals(
+                    manifest.OutputRoot,
+                    OutputManifest.PortableOutputRoot,
+                    StringComparison.Ordinal))
             {
                 throw new InvalidDataException(
-                    "The manifest output root is invalid.",
-                    exception);
-            }
-
-            if (!string.Equals(
-                    canonicalOutputRoot,
-                    manifestOutputRoot,
-                    GetPathComparison()))
-            {
-                throw new InvalidDataException(
-                    "The manifest output root does not match the current output root.");
+                    "The portable manifest output root marker is invalid.");
             }
 
             if (manifest.Files is null)

--- a/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestSerializer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestSerializer.cs
@@ -121,7 +121,7 @@ namespace Xml2Doc.Core.OutputLifecycle
                 manifest);
 
             return new OutputManifest(
-                manifest.SchemaVersion,
+                OutputManifest.CurrentSchemaVersion,
                 manifest.Identity,
                 OutputManifest.PortableOutputRoot,
                 validatedPlan.FilesToDelete);

--- a/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestSerializer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestSerializer.cs
@@ -49,6 +49,7 @@ namespace Xml2Doc.Core.OutputLifecycle
                 OutputManifest.PortableOutputRoot,
                 normalizedFiles
                     .Select(path => path.Replace('\\', '/'))
+                    .OrderBy(path => path, StringComparer.Ordinal)
                     .ToArray());
 
             return JsonSerializer

--- a/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestSerializer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/OutputLifecycle/OutputManifestSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 
 namespace Xml2Doc.Core.OutputLifecycle
@@ -45,8 +46,10 @@ namespace Xml2Doc.Core.OutputLifecycle
             var manifest = new OutputManifest(
                 OutputManifest.CurrentSchemaVersion,
                 location.Identity,
-                location.OutputRoot,
-                normalizedFiles);
+                OutputManifest.PortableOutputRoot,
+                normalizedFiles
+                    .Select(path => path.Replace('\\', '/'))
+                    .ToArray());
 
             return JsonSerializer
                 .Serialize(manifest, SerializerOptions)
@@ -120,7 +123,7 @@ namespace Xml2Doc.Core.OutputLifecycle
             return new OutputManifest(
                 manifest.SchemaVersion,
                 manifest.Identity,
-                location.OutputRoot,
+                OutputManifest.PortableOutputRoot,
                 validatedPlan.FilesToDelete);
         }
     }

--- a/Xml2Doc/tests/Xml2Doc.Tests/OutputLifecycleExecutorTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/OutputLifecycleExecutorTests.cs
@@ -73,6 +73,28 @@ namespace Xml2Doc.Tests
         }
 
         [Fact]
+        public void ExecuteAfterSuccessfulGeneration_WithRelocatedManifest_DeletesOnlyUnderCurrentRoot()
+        {
+            using var original = TemporaryOutput.Create();
+            using var relocated = TemporaryOutput.Create();
+            var originalLocation = original.CreateLocation("project");
+            var relocatedLocation = relocated.CreateLocation("project");
+            original.Write("Stale.md");
+            relocated.Write("Stale.md");
+            OutputManifestStore.Save(originalLocation, new[] { "Stale.md" });
+            Directory.CreateDirectory(
+                System.IO.Path.GetDirectoryName(relocatedLocation.ManifestPath)!);
+            File.Copy(originalLocation.ManifestPath, relocatedLocation.ManifestPath);
+
+            OutputLifecycleExecutor.ExecuteAfterSuccessfulGeneration(
+                relocatedLocation,
+                Array.Empty<string>());
+
+            original.Exists("Stale.md").ShouldBeTrue();
+            relocated.Exists("Stale.md").ShouldBeFalse();
+        }
+
+        [Fact]
         public void ExecuteAfterSuccessfulGeneration_InDryRun_DoesNotMutateFilesOrManifest()
         {
             using var output = TemporaryOutput.Create();

--- a/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestPlannerTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestPlannerTests.cs
@@ -103,17 +103,19 @@ namespace Xml2Doc.Tests
         }
 
         [Fact]
-        public void CreatePlan_WhenPreviousManifestOutputRootDoesNotMatchCurrentCanonicalRoot_ThrowsInvalidDataException()
+        public void CreatePlan_WhenPortableManifestMovesToAnotherOutputRoot_PreservesOwnership()
         {
             var outputRoot = CreateOutputRoot();
             var otherOutputRoot = CreateOutputRoot();
             var previousManifest = CreateManifest(otherOutputRoot, "Owned.md");
 
-            Should.Throw<InvalidDataException>(() =>
-                OutputManifestPlanner.CreatePlan(
-                    outputRoot,
-                    new[] { "Owned.md" },
-                    previousManifest));
+            var plan = OutputManifestPlanner.CreatePlan(
+                outputRoot,
+                new[] { "Owned.md" },
+                previousManifest);
+
+            plan.FilesToWrite.ShouldBe(new[] { "Owned.md" });
+            plan.FilesToDelete.ShouldBeEmpty();
         }
 
         [Fact]

--- a/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestPlannerTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestPlannerTests.cs
@@ -242,11 +242,11 @@ namespace Xml2Doc.Tests
         }
 
         [Fact]
-        public void CreatePlan_WhenManifestOutputRootHasTrailingSeparator_MatchesCurrentRootWithoutTrailingSeparator()
+        public void CreatePlan_WhenLegacyManifestOutputRootHasTrailingSeparator_MigratesOwnership()
         {
             var outputRoot = CreateOutputRoot();
             var previousManifest = new OutputManifest(
-                OutputManifest.CurrentSchemaVersion,
+                1,
                 "test-invocation",
                 EnsureTrailingDirectorySeparator(outputRoot),
                 new[] { "Owned.md" });
@@ -486,7 +486,7 @@ namespace Xml2Doc.Tests
             new(
                 OutputManifest.CurrentSchemaVersion,
                 "test-invocation",
-                Path.GetFullPath(outputRoot),
+                OutputManifest.PortableOutputRoot,
                 files);
     }
 }

--- a/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestSerializerTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestSerializerTests.cs
@@ -24,9 +24,9 @@ namespace Xml2Doc.Tests
 
             json.ShouldBe(
                 "{\n" +
-                "  \"schemaVersion\": 1,\n" +
+                "  \"schemaVersion\": 2,\n" +
                 "  \"identity\": \"sample-project\",\n" +
-                $"  \"outputRoot\": {SerializeJsonString(location.OutputRoot)},\n" +
+                "  \"outputRoot\": \".\",\n" +
                 "  \"files\": [\n" +
                 "    \"Alpha.md\",\n" +
                 "    \"beta.md\",\n" +
@@ -45,6 +45,17 @@ namespace Xml2Doc.Tests
             var second = OutputManifestSerializer.Serialize(location, files);
 
             first.ShouldBe(second);
+        }
+
+        [Fact]
+        public void Serialize_UsesPortableForwardSlashesForNestedFiles()
+        {
+            var location = CreateLocation("project");
+            var nested = "api" + Path.DirectorySeparatorChar + "Widget.md";
+
+            var json = OutputManifestSerializer.Serialize(location, new[] { nested });
+
+            json.ShouldContain("\"api/Widget.md\"");
         }
 
         [Fact]
@@ -73,7 +84,7 @@ namespace Xml2Doc.Tests
 
             manifest.SchemaVersion.ShouldBe(OutputManifest.CurrentSchemaVersion);
             manifest.Identity.ShouldBe("project");
-            manifest.OutputRoot.ShouldBe(location.OutputRoot);
+            manifest.OutputRoot.ShouldBe(OutputManifest.PortableOutputRoot);
             manifest.Files.ShouldBe(new[] { "Widget.md", "index.md" });
         }
 
@@ -102,7 +113,7 @@ namespace Xml2Doc.Tests
         }
 
         [Fact]
-        public void Deserialize_WhenManifestOutputRootDoesNotMatch_ThrowsInvalidDataException()
+        public void Deserialize_WhenManifestIsMovedToAnotherOutputRoot_LoadsPortableOwnership()
         {
             var storedLocation = CreateLocation("project");
             var requestedLocation = CreateLocation("project");
@@ -110,8 +121,10 @@ namespace Xml2Doc.Tests
                 storedLocation,
                 new[] { "Widget.md" });
 
-            Should.Throw<InvalidDataException>(() =>
-                OutputManifestSerializer.Deserialize(json, requestedLocation));
+            var manifest = OutputManifestSerializer.Deserialize(json, requestedLocation);
+
+            manifest.Files.ShouldBe(new[] { "Widget.md" });
+            manifest.OutputRoot.ShouldBe(OutputManifest.PortableOutputRoot);
         }
 
         [Fact]
@@ -122,8 +135,8 @@ namespace Xml2Doc.Tests
                     location,
                     new[] { "Widget.md" })
                 .Replace(
-                    "\"schemaVersion\": 1",
-                    "\"schemaVersion\": 2");
+                    "\"schemaVersion\": 2",
+                    "\"schemaVersion\": 3");
 
             Should.Throw<InvalidDataException>(() =>
                 OutputManifestSerializer.Deserialize(json, location));
@@ -139,6 +152,41 @@ namespace Xml2Doc.Tests
                 .Replace(
                     "\"Widget.md\"",
                     "\"../outside.md\"");
+
+            Should.Throw<InvalidDataException>(() =>
+                OutputManifestSerializer.Deserialize(json, location));
+        }
+
+        [Fact]
+        public void Deserialize_WhenLegacyManifestMovesAcrossWindowsAndUnixRoots_MigratesSafely()
+        {
+            var location = CreateLocation("project");
+            var json =
+                "{" +
+                "\"schemaVersion\":1," +
+                "\"identity\":\"project\"," +
+                "\"outputRoot\":\"D:\\\\old-checkout\\\\docs\"," +
+                "\"files\":[\"nested\\\\Widget.md\"]" +
+                "}";
+
+            var manifest = OutputManifestSerializer.Deserialize(json, location);
+
+            manifest.SchemaVersion.ShouldBe(OutputManifest.CurrentSchemaVersion);
+            manifest.OutputRoot.ShouldBe(OutputManifest.PortableOutputRoot);
+            manifest.Files.ShouldBe(new[]
+            {
+                "nested" + Path.DirectorySeparatorChar + "Widget.md"
+            });
+        }
+
+        [Fact]
+        public void Deserialize_WhenPortableRootMarkerIsInvalid_ThrowsInvalidDataException()
+        {
+            var location = CreateLocation("project");
+            var json = OutputManifestSerializer.Serialize(
+                    location,
+                    new[] { "Widget.md" })
+                .Replace("\"outputRoot\": \".\"", "\"outputRoot\": \"../outside\"");
 
             Should.Throw<InvalidDataException>(() =>
                 OutputManifestSerializer.Deserialize(json, location));

--- a/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestSerializerTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/OutputManifestSerializerTests.cs
@@ -59,6 +59,21 @@ namespace Xml2Doc.Tests
         }
 
         [Fact]
+        public void Serialize_SortsAfterConvertingToPortableSeparators()
+        {
+            var location = CreateLocation("project");
+            var nested = "api" + Path.DirectorySeparatorChar + "Widget.md";
+
+            var json = OutputManifestSerializer.Serialize(
+                location,
+                new[] { "api0.md", nested });
+
+            json.IndexOf("\"api/Widget.md\"", StringComparison.Ordinal)
+                .ShouldBeLessThan(
+                    json.IndexOf("\"api0.md\"", StringComparison.Ordinal));
+        }
+
+        [Fact]
         public void Serialize_WhenOwnedPathIsUnsafe_ThrowsArgumentException()
         {
             var location = CreateLocation("project");

--- a/docs/adr/ADR-012-invocation-scoped-manifest-identity-storage.md
+++ b/docs/adr/ADR-012-invocation-scoped-manifest-identity-storage.md
@@ -33,9 +33,11 @@ also introduce invalid-character, traversal, length, and collision risks.
    Hashing makes the storage path deterministic and prevents identity text from becoming path
    syntax. The `.xml2doc` directory is reserved for Xml2Doc lifecycle metadata and is not part of
    the generated Markdown output set.
-4. The manifest records its original identity as well as its schema version, canonical output root,
-   and normalized output-root-relative owned paths. Loading verifies that the stored identity
-   ordinally matches the requested identity in addition to the existing schema and output-root
+4. The manifest records its original identity, schema version, a portable current-root marker, and
+   normalized output-root-relative owned paths. Loading verifies that the stored identity ordinally
+   matches the requested identity. The caller's current output root is always the deletion boundary;
+   a manifest never supplies an absolute deletion root. Schema 1 manifests containing an absolute
+   root migrate on their next successful save after their relative entries pass current safety
    validation.
 5. CLI and MSBuild expose the same explicit Core identity concept. A shared output directory uses a
    distinct stable identity for each independent invocation. Reusing an identity intentionally
@@ -49,6 +51,9 @@ also introduce invalid-character, traversal, length, and collision risks.
 - Independent projects can share an output root while maintaining disjoint ownership histories.
 - Manifest locations are stable across checkout directories, machines, configurations, and target
   frameworks when callers retain the same identity.
+- The `manifests` directory may be versioned when generated Markdown is versioned so clean checkouts
+  retain stale-file ownership. The `transactions` directory is local staging state and must be
+  ignored.
 - Identity values cannot escape the metadata directory or create platform-specific filenames.
 - A hash collision is cryptographically improbable, and the identity stored in the manifest allows
   a mismatch to fail safely instead of authorizing deletion.


### PR DESCRIPTION
## Summary

- introduce manifest schema 2 with a portable current-root marker
- migrate safe schema 1 ownership manifests on their next successful save
- canonicalize stored relative paths with portable separators
- keep every stale-file deletion anchored to the caller's current output root
- document which lifecycle state should be committed and which should remain local
- add regression coverage for relocation, Windows/Unix roots, unsafe paths, and identity isolation

## Root cause

Schema 1 persisted the canonical absolute output directory and required it to match the current checkout. A manifest committed from one machine therefore failed when loaded from another checkout, even though all owned files were already stored as output-root-relative paths.

## Impact

Starting with 2.0.3, projects that version generated Markdown can also version `docs/.xml2doc/manifests` so clean builds retain stale-output ownership. `docs/.xml2doc/transactions` remains local staging state and should stay ignored.

## Validation

- `git diff --check`
- local and remote blob SHAs verified identical for all eight changed files
- GitHub Actions will provide authoritative .NET build and test validation because this workspace does not include the .NET SDK

Closes #77