### PR TITLE
Regenerate missing MSBuild outputs

### DIFF
--- a/.github/workflows/msbuild-integration.yml
+++ b/.github/workflows/msbuild-integration.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   msbuild_integration:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
     env:
       MSBUILDDISABLENODEREUSE: "1"
     steps:
@@ -37,30 +40,30 @@ jobs:
         run: dotnet build-server shutdown
 
       - name: Clean
-        run: dotnet clean ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --configuration Release --disable-build-servers
+        run: dotnet clean ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --configuration ${{ matrix.configuration }} --disable-build-servers
 
       - name: Restore
         run: dotnet restore ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --disable-build-servers
 
       - name: Build (no servers)
-        run: dotnet build ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --configuration Release --no-restore --disable-build-servers
+        run: dotnet build ${{ github.workspace }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}.sln --configuration ${{ matrix.configuration }} --no-restore --disable-build-servers
 
       - name: MSBuild integration (script)
         shell: pwsh
-        run: ./scripts/test-msbuild-integration.ps1 -Configuration Release -KeepArtifacts
+        run: ./scripts/test-msbuild-integration.ps1 -Configuration ${{ matrix.configuration }} -KeepArtifacts
 
       - name: Upload MSBuild integration artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: msbuild-integration-artifacts
+          name: msbuild-integration-artifacts-${{ matrix.configuration }}
           path: |
-            Xml2Doc/tests/Xml2Doc.Sample/obj/Release/xml2doc-it/**
-            Xml2Doc/tests/Xml2Doc.Sample/obj/Release/net9.0/xml2doc.stamp
+            Xml2Doc/tests/Xml2Doc.Sample/obj/${{ matrix.configuration }}/xml2doc-it/**
+            Xml2Doc/tests/Xml2Doc.Sample/obj/${{ matrix.configuration }}/net9.0/xml2doc.stamp
 
       - name: Upload integration test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: MSBuild Integration Test Results
+          name: MSBuild Integration Test Results (${{ matrix.configuration }})
           path: '**/TestResults/*.trx'

--- a/Xml2Doc.md
+++ b/Xml2Doc.md
@@ -156,6 +156,7 @@ These are advanced settings; most consumers should retain the defaults.
 | --- | --- | --- |
 | `Xml2Doc_OutputStamp` | `$(IntermediateOutputPath)xml2doc.stamp` | Successful-generation stamp used by MSBuild input/output tracking. Relative paths are rooted under `IntermediateOutputPath`. |
 | `Xml2Doc_FingerprintFile` | `$(IntermediateOutputPath)xml2doc.fingerprint.txt` | Stores a fingerprint of XML content and significant options. Relative paths are rooted under `IntermediateOutputPath`. |
+| `Xml2Doc_OutputLedger` | `$(IntermediateOutputPath)xml2doc.outputs.txt` | Records generated files so a missing output invalidates the incremental stamp. Keep this under the project/configuration-specific intermediate directory. |
 
 Do not add an `Xml2Doc_WriteFingerprint` target. The imported targets already manage fingerprinting and generation.
 

--- a/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.props
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.props
@@ -31,6 +31,7 @@
     <Xml2Doc_OutputStamp Condition="'$(Xml2Doc_OutputStamp)'==''">$(IntermediateOutputPath)xml2doc.stamp</Xml2Doc_OutputStamp>
 
     <Xml2Doc_FingerprintFile Condition="'$(Xml2Doc_FingerprintFile)'==''">$(IntermediateOutputPath)xml2doc.fingerprint.txt</Xml2Doc_FingerprintFile>
+    <Xml2Doc_OutputLedger Condition="'$(Xml2Doc_OutputLedger)'==''">$(IntermediateOutputPath)xml2doc.outputs.txt</Xml2Doc_OutputLedger>
 
     <!-- Optional behavior switches -->
     <Xml2Doc_DryRun Condition="'$(Xml2Doc_DryRun)'==''">false</Xml2Doc_DryRun>

--- a/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
@@ -62,7 +62,7 @@
           Condition="
             '$(Xml2Doc_Enabled)' != '' and '$(Xml2Doc_Enabled)' != 'false' and '$(Xml2Doc_Enabled)' != 'False'
             and '$(GenerateDocumentationFile)' == 'true'
-            and '$(Xml2Doc_DryRun)' != 'true'
+            and '$(Xml2Doc_DryRun)' != 'true' and '$(Xml2Doc_DryRun)' != 'True'
             and Exists('$(Xml2Doc_OutputStamp)')">
     <ItemGroup>
       <_Xml2Doc_RecordedOutput Remove="@(_Xml2Doc_RecordedOutput)" />
@@ -217,7 +217,7 @@
                       Lines="@(Xml2Doc_GeneratedFiles)"
                       Overwrite="true"
                       Encoding="UTF-8"
-                      Condition="'$(Xml2Doc_DryRun)' != 'true'" />
+                      Condition="'$(Xml2Doc_DryRun)' != 'true' and '$(Xml2Doc_DryRun)' != 'True'" />
   </Target>
 
 </Project>

--- a/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
+++ b/Xml2Doc/src/Xml2Doc.MSBuild/build/Xml2Doc.MSBuild.targets
@@ -39,11 +39,14 @@
   <PropertyGroup>
     <Xml2Doc_OutputStamp Condition="'$(Xml2Doc_OutputStamp)' == ''">$(IntermediateOutputPath)xml2doc.stamp</Xml2Doc_OutputStamp>
     <Xml2Doc_FingerprintFile Condition="'$(Xml2Doc_FingerprintFile)' == ''">$(IntermediateOutputPath)xml2doc.fingerprint.txt</Xml2Doc_FingerprintFile>
+    <Xml2Doc_OutputLedger Condition="'$(Xml2Doc_OutputLedger)' == ''">$(IntermediateOutputPath)xml2doc.outputs.txt</Xml2Doc_OutputLedger>
 
     <Xml2Doc_OutputStamp Condition="!$([System.IO.Path]::IsPathRooted('$(Xml2Doc_OutputStamp)'))">$(IntermediateOutputPath)$(Xml2Doc_OutputStamp)</Xml2Doc_OutputStamp>
     <Xml2Doc_FingerprintFile Condition="!$([System.IO.Path]::IsPathRooted('$(Xml2Doc_FingerprintFile)'))">$(IntermediateOutputPath)$(Xml2Doc_FingerprintFile)</Xml2Doc_FingerprintFile>
+    <Xml2Doc_OutputLedger Condition="!$([System.IO.Path]::IsPathRooted('$(Xml2Doc_OutputLedger)'))">$(IntermediateOutputPath)$(Xml2Doc_OutputLedger)</Xml2Doc_OutputLedger>
 
     <_Xml2Doc_OutputStampDir>$([System.IO.Path]::GetDirectoryName('$(Xml2Doc_OutputStamp)'))</_Xml2Doc_OutputStampDir>
+    <_Xml2Doc_OutputLedgerDir>$([System.IO.Path]::GetDirectoryName('$(Xml2Doc_OutputLedger)'))</_Xml2Doc_OutputLedgerDir>
     <_Xml2Doc_OutputFileDir Condition="'$(Xml2Doc_OutputFile)' != ''">$([System.IO.Path]::GetDirectoryName('$(Xml2Doc_OutputFile)'))</_Xml2Doc_OutputFileDir>
   </PropertyGroup>
 
@@ -53,6 +56,31 @@
           BeforeTargets="Xml2Doc_Generate"
           Condition="!Exists('$(_Xml2Doc_TaskPath)')">
     <Warning Text="Xml2Doc task assembly not found at $(_Xml2Doc_TaskPath). Package layout mismatch?" />
+  </Target>
+
+  <Target Name="Xml2Doc_ValidateOutputs"
+          Condition="
+            '$(Xml2Doc_Enabled)' != '' and '$(Xml2Doc_Enabled)' != 'false' and '$(Xml2Doc_Enabled)' != 'False'
+            and '$(GenerateDocumentationFile)' == 'true'
+            and '$(Xml2Doc_DryRun)' != 'true'
+            and Exists('$(Xml2Doc_OutputStamp)')">
+    <ItemGroup>
+      <_Xml2Doc_RecordedOutput Remove="@(_Xml2Doc_RecordedOutput)" />
+      <_Xml2Doc_MissingOutput Remove="@(_Xml2Doc_MissingOutput)" />
+    </ItemGroup>
+
+    <ReadLinesFromFile File="$(Xml2Doc_OutputLedger)"
+                       Condition="Exists('$(Xml2Doc_OutputLedger)')">
+      <Output TaskParameter="Lines" ItemName="_Xml2Doc_RecordedOutput" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <_Xml2Doc_MissingOutput Include="@(_Xml2Doc_RecordedOutput)"
+                              Condition="!Exists('%(_Xml2Doc_RecordedOutput.Identity)')" />
+    </ItemGroup>
+
+    <Delete Files="$(Xml2Doc_OutputStamp)"
+            Condition="!Exists('$(Xml2Doc_OutputLedger)') or '@(_Xml2Doc_MissingOutput)' != ''" />
   </Target>
 
   <Target Name="_Xml2Doc_LogChosenTask"
@@ -129,7 +157,7 @@
 
   <Target Name="Xml2Doc_Generate"
           AfterTargets="CoreCompile"
-          DependsOnTargets="Xml2Doc_ComputeFingerprint"
+          DependsOnTargets="Xml2Doc_ComputeFingerprint;Xml2Doc_ValidateOutputs"
           Condition="
             '$(Xml2Doc_Enabled)' != '' and '$(Xml2Doc_Enabled)' != 'false' and '$(Xml2Doc_Enabled)' != 'False'
             and '$(GenerateDocumentationFile)' == 'true'
@@ -145,6 +173,8 @@
              Condition="'$(Xml2Doc_SingleFile)'=='true' and '$(_Xml2Doc_OutputFileDir)'!='' and !Exists('$(_Xml2Doc_OutputFileDir)')" />
     <MakeDir Directories="$(_Xml2Doc_OutputStampDir)"
              Condition="'$(_Xml2Doc_OutputStampDir)' != '' and !Exists('$(_Xml2Doc_OutputStampDir)')" />
+    <MakeDir Directories="$(_Xml2Doc_OutputLedgerDir)"
+             Condition="'$(_Xml2Doc_OutputLedgerDir)' != '' and !Exists('$(_Xml2Doc_OutputLedgerDir)')" />
 
     <GenerateMarkdownFromXmlDoc XmlPath="$(DocumentationFile)"
                                 ReferenceXmlPaths="@(_Xml2Doc_AutomaticReferenceXml);@(Xml2Doc_ReferenceXml)"
@@ -182,6 +212,12 @@
                       Overwrite="true"
                       Encoding="UTF-8"
                       Condition="'$(Xml2Doc_DidWork)'=='true' or !Exists('$(Xml2Doc_OutputStamp)')" />
+
+    <WriteLinesToFile File="$(Xml2Doc_OutputLedger)"
+                      Lines="@(Xml2Doc_GeneratedFiles)"
+                      Overwrite="true"
+                      Encoding="UTF-8"
+                      Condition="'$(Xml2Doc_DryRun)' != 'true'" />
   </Target>
 
 </Project>

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -269,6 +269,13 @@ namespace Xml2Doc.Tests
             validateOutputsTarget.Descendants("Delete")
                 .Single().Attribute("Files")!.Value
                 .ShouldBe("$(Xml2Doc_OutputStamp)");
+            validateOutputsTarget.Attribute("Condition")!.Value
+                .ShouldContain("'$(Xml2Doc_DryRun)' != 'True'");
+            generateTarget.Descendants("WriteLinesToFile")
+                .Single(element =>
+                    element.Attribute("File")?.Value == "$(Xml2Doc_OutputLedger)")
+                .Attribute("Condition")!.Value
+                .ShouldContain("'$(Xml2Doc_DryRun)' != 'True'");
         }
 
         [Fact]

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -258,11 +258,15 @@ namespace Xml2Doc.Tests
                 .ShouldBe("$(Xml2Doc_LineEndings)");
             taskElement.Attribute("ReferenceXmlPaths")!.Value
                 .ShouldBe("@(_Xml2Doc_AutomaticReferenceXml);@(Xml2Doc_ReferenceXml)");
-            targets.Descendants("Xml2Doc_Generate")
-                .Single().Attribute("DependsOnTargets")!.Value
+            var generateTarget = targets.Descendants("Target")
+                .Single(element =>
+                    element.Attribute("Name")?.Value == "Xml2Doc_Generate");
+            var validateOutputsTarget = targets.Descendants("Target")
+                .Single(element =>
+                    element.Attribute("Name")?.Value == "Xml2Doc_ValidateOutputs");
+            generateTarget.Attribute("DependsOnTargets")!.Value
                 .ShouldContain("Xml2Doc_ValidateOutputs");
-            targets.Descendants("Xml2Doc_ValidateOutputs")
-                .Single().Descendants("Delete")
+            validateOutputsTarget.Descendants("Delete")
                 .Single().Attribute("Files")!.Value
                 .ShouldBe("$(Xml2Doc_OutputStamp)");
         }

--- a/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/GenerateMarkdownFromXmlDocTests.cs
@@ -238,6 +238,8 @@ namespace Xml2Doc.Tests
                 .Single().Value.ShouldBe("false");
             props.Descendants("Xml2Doc_ManifestIdentity")
                 .Single().Value.ShouldBeEmpty();
+            props.Descendants("Xml2Doc_OutputLedger")
+                .Single().Value.ShouldBe("$(IntermediateOutputPath)xml2doc.outputs.txt");
 
             var taskElement = targets
                 .Descendants("GenerateMarkdownFromXmlDoc")
@@ -256,6 +258,13 @@ namespace Xml2Doc.Tests
                 .ShouldBe("$(Xml2Doc_LineEndings)");
             taskElement.Attribute("ReferenceXmlPaths")!.Value
                 .ShouldBe("@(_Xml2Doc_AutomaticReferenceXml);@(Xml2Doc_ReferenceXml)");
+            targets.Descendants("Xml2Doc_Generate")
+                .Single().Attribute("DependsOnTargets")!.Value
+                .ShouldContain("Xml2Doc_ValidateOutputs");
+            targets.Descendants("Xml2Doc_ValidateOutputs")
+                .Single().Descendants("Delete")
+                .Single().Attribute("Files")!.Value
+                .ShouldBe("$(Xml2Doc_OutputStamp)");
         }
 
         [Fact]

--- a/scripts/test-msbuild-integration.ps1
+++ b/scripts/test-msbuild-integration.ps1
@@ -206,6 +206,7 @@ function Show-PathState([string] $label, [string] $path)
 $bin1 = Join-Path $runRoot "build1.binlog"
 $bin2 = Join-Path $runRoot "build2.binlog"
 $bin3 = Join-Path $runRoot "build3.binlog"
+$bin4 = Join-Path $runRoot "build4.binlog"
 
 Write-Step "Build 1: per-type output"
 $r1 = Invoke-SampleBuild -SingleFile:$false -BinLogPath $bin1
@@ -244,18 +245,32 @@ Assert-True ($t2 -eq $t1) ("Expected incremental no-op build (stamp unchanged).`
 
 Start-Sleep -Milliseconds 600
 
-Write-Step "Build 3: switch to single-file mode, expect re-run"
-$r3 = Invoke-SampleBuild -SingleFile:$true -BinLogPath $bin3
+Write-Step "Build 3: delete one recorded output, expect regeneration"
+$missingOutput = Join-Path $outDir "index.md"
+Remove-Item -LiteralPath $missingOutput -Force
+Assert-True (-not (Test-Path $missingOutput)) "Expected recorded output to be deleted before recovery build"
+$r3 = Invoke-SampleBuild -SingleFile:$false -BinLogPath $bin3
 
 $t3 = (Get-Item $stampDefault).LastWriteTimeUtc
-Write-Detail "Stamp after build 3: $t3"
+Write-Detail "Stamp after missing-output recovery: $t3"
 
-Assert-True ($t3 -gt $t2) ("Expected stamp to update after option change.`n`t2=$t2`n`t3=$t3")
+Assert-True ($t3 -gt $t2) ("Expected stamp to update after a recorded output was deleted.`n`t2=$t2`n`t3=$t3")
+Assert-True (Test-Path $missingOutput) "Expected missing generated output to be restored at $missingOutput"
+
+Start-Sleep -Milliseconds 600
+
+Write-Step "Build 4: switch to single-file mode, expect re-run"
+$r4 = Invoke-SampleBuild -SingleFile:$true -BinLogPath $bin4
+
+$t4 = (Get-Item $stampDefault).LastWriteTimeUtc
+Write-Detail "Stamp after build 4: $t4"
+
+Assert-True ($t4 -gt $t3) ("Expected stamp to update after option change.`n`t3=$t3`n`t4=$t4")
 Assert-True (Test-Path $outFile) "Expected single-file output at $outFile"
 Assert-True (Test-Path $report) "Expected report to exist at $report"
 
-$rep3 = Get-Content $report -Raw | ConvertFrom-Json
-Assert-True ($rep3.single -eq $true) "Expected report.single=true after single-file build"
+$rep4 = Get-Content $report -Raw | ConvertFrom-Json
+Assert-True ($rep4.single -eq $true) "Expected report.single=true after single-file build"
 
 Write-Detail "Final output tree:"
 (Get-Tree $runRoot).Split([Environment]::NewLine) | ForEach-Object {


### PR DESCRIPTION
## Summary

- persist the generated output set in a project/configuration-scoped MSBuild ledger
- invalidate the incremental output stamp when the ledger or any recorded output is missing
- regenerate deleted Markdown on the next normal build while preserving no-op behavior when all outputs exist
- cover missing-output recovery in the MSBuild integration script
- run MSBuild integration coverage for both Debug and Release configurations
- document the advanced `Xml2Doc_OutputLedger` property

## Root cause

`Xml2Doc_Generate` used the fingerprint as its input and only the stamp as its output. MSBuild therefore skipped generation whenever the stamp was current, even if one of the Markdown files produced by the previous invocation had been deleted.

## Impact

A normal build now restores generated Markdown that is missing from the recorded output set. The ledger defaults under `IntermediateOutputPath`, so Debug and Release state remains isolated and normal cleaning removes the incremental state consistently.

## Validation

- `git diff --check`
- build-asset unit assertions cover ledger defaults and target wiring
- the MSBuild integration scenario verifies no-op behavior, deletion recovery, and mode changes
- GitHub Actions provides authoritative .NET and PowerShell validation because this workspace does not include the .NET SDK or PowerShell

Closes #79