### PR TITLE
Add rendering link parity matrix

### DIFF
--- a/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
@@ -1,0 +1,146 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xml2Doc.Core;
+using Xunit;
+
+namespace Xml2Doc.Tests
+{
+    public class RenderingParityMatrixTests
+    {
+        public static IEnumerable<object[]> LinkRoutingMatrix()
+        {
+            foreach (var algorithm in Enum.GetValues<AnchorAlgorithm>())
+            {
+                yield return new object[] { algorithm, false };
+                yield return new object[] { algorithm, true };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LinkRoutingMatrix))]
+        public async Task InternalLinks_ResolveForEveryModeAndAnchorAlgorithm(
+            AnchorAlgorithm algorithm,
+            bool singleFile)
+        {
+            var root = Path.Combine(
+                Path.GetTempPath(),
+                "Xml2Doc.Tests",
+                Path.GetRandomFileName());
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                var xmlPath = Path.Combine(root, "matrix.xml");
+                await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
+                var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+                var renderer = new MarkdownRenderer(
+                    model,
+                    new RendererOptions(
+                        FileNameMode: FileNameMode.CleanGenerics,
+                        RootNamespaceToTrim: null,
+                        CodeBlockLanguage: "csharp",
+                        AnchorAlgorithm: algorithm));
+
+                if (singleFile)
+                {
+                    var output = Path.Combine(root, "api.md");
+                    renderer.RenderToSingleFile(output);
+                    var markdown = Normalize(await File.ReadAllTextAsync(output));
+
+                    var typeHref = ExtractHref(markdown, "HTTP_Parser_v2");
+                    typeHref.ShouldStartWith("#");
+                    AssertAnchorExists(markdown, typeHref.Substring(1));
+
+                    var memberHref = ExtractHref(markdown, "Do(string)");
+                    memberHref.ShouldStartWith("#");
+                    AssertAnchorExists(markdown, memberHref.Substring(1));
+                }
+                else
+                {
+                    var output = Path.Combine(root, "docs");
+                    renderer.RenderToDirectory(output);
+                    var consumer = Normalize(await File.ReadAllTextAsync(
+                        Path.Combine(output, "Temp.Consumer.md")));
+                    var targetPath = Path.Combine(output, "Temp.HTTP_Parser_v2.md");
+                    var target = Normalize(await File.ReadAllTextAsync(targetPath));
+
+                    ExtractHref(consumer, "HTTP_Parser_v2")
+                        .ShouldBe("Temp.HTTP_Parser_v2.md");
+
+                    var memberHref = ExtractHref(consumer, "Do(string)");
+                    memberHref.ShouldStartWith("Temp.HTTP_Parser_v2.md#");
+                    AssertAnchorExists(
+                        target,
+                        memberHref.Substring(memberHref.IndexOf('#') + 1));
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
+        }
+
+        private static string ExtractHref(string markdown, string label)
+        {
+            var marker = $"[{label}](";
+            var start = markdown.IndexOf(marker, StringComparison.Ordinal);
+            start.ShouldBeGreaterThanOrEqualTo(0, $"Missing link label '{label}'.");
+            start += marker.Length;
+            var depth = 1;
+            var end = start;
+
+            while (end < markdown.Length && depth > 0)
+            {
+                if (markdown[end] == '(')
+                {
+                    depth++;
+                }
+                else if (markdown[end] == ')')
+                {
+                    depth--;
+                }
+
+                end++;
+            }
+
+            end--;
+            end.ShouldBeGreaterThan(start, $"Missing link destination for '{label}'.");
+            return markdown.Substring(start, end - start);
+        }
+
+        private static void AssertAnchorExists(string markdown, string anchor) =>
+            markdown.ShouldContain($"<a id=\"{anchor}\"></a>");
+
+        private static string Normalize(string markdown) =>
+            markdown.Replace("\r\n", "\n");
+
+        private const string FixtureXml = """
+            <?xml version="1.0"?>
+            <doc>
+              <assembly><name>Temp</name></assembly>
+              <members>
+                <member name="T:Temp.Consumer">
+                  <summary>
+                    See <see cref="T:Temp.HTTP_Parser_v2"/> and
+                    <see cref="M:Temp.HTTP_Parser_v2.Do(System.String)"/>.
+                  </summary>
+                </member>
+                <member name="T:Temp.HTTP_Parser_v2">
+                  <summary>Parses HTTP values.</summary>
+                </member>
+                <member name="M:Temp.HTTP_Parser_v2.Do(System.String)">
+                  <summary>Does work.</summary>
+                  <param name="value">Input value.</param>
+                </member>
+              </members>
+            </doc>
+            """;
+    }
+}

--- a/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
@@ -49,7 +49,7 @@ namespace Xml2Doc.Tests
                 {
                     var output = ChildPath(root, "api.md");
                     renderer.RenderToSingleFile(output);
-                    var markdown = Normalize(await File.ReadAllTextAsync(output));
+                    var markdown = await ReadRequiredMarkdownAsync(output);
 
                     var typeHref = ExtractHref(markdown, "HTTP_Parser_v2");
                     typeHref.ShouldStartWith("#");
@@ -63,10 +63,10 @@ namespace Xml2Doc.Tests
                 {
                     var output = ChildPath(root, "docs");
                     renderer.RenderToDirectory(output);
-                    var consumer = Normalize(await File.ReadAllTextAsync(
-                        ChildPath(output, "Temp.Consumer.md")));
+                    var consumer = await ReadRequiredMarkdownAsync(
+                        ChildPath(output, "Temp.Consumer.md"));
                     var targetPath = ChildPath(output, "Temp.HTTP_Parser_v2.md");
-                    var target = Normalize(await File.ReadAllTextAsync(targetPath));
+                    var target = await ReadRequiredMarkdownAsync(targetPath);
 
                     ExtractHref(consumer, "HTTP_Parser_v2")
                         .ShouldBe("Temp.HTTP_Parser_v2.md");
@@ -117,6 +117,12 @@ namespace Xml2Doc.Tests
 
         private static void AssertAnchorExists(string markdown, string anchor) =>
             markdown.ShouldContain($"<a id=\"{anchor}\"></a>");
+
+        private static async Task<string> ReadRequiredMarkdownAsync(string path)
+        {
+            File.Exists(path).ShouldBeTrue($"Missing expected Markdown output: {path}");
+            return Normalize(await File.ReadAllTextAsync(path));
+        }
 
         private static string ChildPath(string root, string relativePath)
         {

--- a/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
@@ -26,15 +26,15 @@ namespace Xml2Doc.Tests
             AnchorAlgorithm algorithm,
             bool singleFile)
         {
-            var root = Path.Combine(
-                Path.GetTempPath(),
-                "Xml2Doc.Tests",
-                Path.GetRandomFileName());
+            var tempTestRoot = ChildPath(Path.GetTempPath(), "Xml2Doc.Tests");
+            var root = ChildPath(
+                tempTestRoot,
+                Path.GetFileName(Path.GetRandomFileName()));
 
             try
             {
                 Directory.CreateDirectory(root);
-                var xmlPath = Path.Combine(root, "matrix.xml");
+                var xmlPath = ChildPath(root, "matrix.xml");
                 await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
                 var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
                 var renderer = new MarkdownRenderer(
@@ -47,7 +47,7 @@ namespace Xml2Doc.Tests
 
                 if (singleFile)
                 {
-                    var output = Path.Combine(root, "api.md");
+                    var output = ChildPath(root, "api.md");
                     renderer.RenderToSingleFile(output);
                     var markdown = Normalize(await File.ReadAllTextAsync(output));
 
@@ -61,11 +61,11 @@ namespace Xml2Doc.Tests
                 }
                 else
                 {
-                    var output = Path.Combine(root, "docs");
+                    var output = ChildPath(root, "docs");
                     renderer.RenderToDirectory(output);
                     var consumer = Normalize(await File.ReadAllTextAsync(
-                        Path.Combine(output, "Temp.Consumer.md")));
-                    var targetPath = Path.Combine(output, "Temp.HTTP_Parser_v2.md");
+                        ChildPath(output, "Temp.Consumer.md")));
+                    var targetPath = ChildPath(output, "Temp.HTTP_Parser_v2.md");
                     var target = Normalize(await File.ReadAllTextAsync(targetPath));
 
                     ExtractHref(consumer, "HTTP_Parser_v2")
@@ -117,6 +117,34 @@ namespace Xml2Doc.Tests
 
         private static void AssertAnchorExists(string markdown, string anchor) =>
             markdown.ShouldContain($"<a id=\"{anchor}\"></a>");
+
+        private static string ChildPath(string root, string relativePath)
+        {
+            if (Path.IsPathRooted(relativePath))
+            {
+                throw new ArgumentException(
+                    "The child path must be relative.",
+                    nameof(relativePath));
+            }
+
+            var canonicalRoot = Path.GetFullPath(root);
+            var candidate = Path.GetFullPath(Path.Join(canonicalRoot, relativePath));
+            var rootWithSeparator =
+                Path.TrimEndingDirectorySeparator(canonicalRoot) +
+                Path.DirectorySeparatorChar;
+            var comparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!candidate.StartsWith(rootWithSeparator, comparison))
+            {
+                throw new ArgumentException(
+                    "The child path must remain under the requested root.",
+                    nameof(relativePath));
+            }
+
+            return candidate;
+        }
 
         private static string Normalize(string markdown) =>
             markdown.Replace("\r\n", "\n");


### PR DESCRIPTION
## Summary

- add a mode × anchor-algorithm link-routing matrix
- cover Default, GitHub, GFM, and Kramdown algorithms
- exercise both per-type and single-file rendering
- verify type links resolve to emitted files or heading anchors
- verify member links resolve to anchors that actually exist in the destination document

## Why

The 2.1.0 renderer refactors will extract anchor, alias, signature, template, and linking behavior behind extension points. This matrix establishes link-routing parity before those production changes begin.

## Scope

This is the first slice of #43. The issue remains open for expanded committed snapshots and auto-linker code-fence safety coverage.

## Validation

- `git diff --check`
- remote and local test-file blobs verified identical
- GitHub Actions provides authoritative .NET validation because this workspace does not include the .NET SDK

Refs #43