### PR TITLE
Extract configurable alias provider

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/Aliasing/DefaultAliasProvider.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Aliasing/DefaultAliasProvider.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Xml2Doc.Core.Aliasing
+{
+    /// <summary>
+    /// Applies the built-in C# keyword aliases for framework type tokens.
+    /// </summary>
+    public sealed class DefaultAliasProvider : IAliasProvider
+    {
+        private static readonly (string Full, string Alias)[] Aliases =
+        {
+            ("System.String", "string"), ("System.Int32", "int"),
+            ("System.Boolean", "bool"), ("System.Object", "object"),
+            ("System.Void", "void"), ("System.Int64", "long"),
+            ("System.Int16", "short"), ("System.Byte", "byte"),
+            ("System.SByte", "sbyte"), ("System.UInt32", "uint"),
+            ("System.UInt64", "ulong"), ("System.UInt16", "ushort"),
+            ("System.Char", "char"), ("System.Decimal", "decimal"),
+            ("System.Double", "double"), ("System.Single", "float")
+        };
+
+        private static readonly IReadOnlyList<(Regex Pattern, string Alias)>
+            FullTokenPatterns = Aliases
+                .Select(alias =>
+                    (new Regex(
+                        $@"(?<![A-Za-z0-9_]){Regex.Escape(alias.Full)}(?![A-Za-z0-9_])"),
+                     alias.Alias))
+                .ToArray();
+
+        private static readonly IReadOnlyList<(Regex Pattern, string Alias)>
+            ShortTokenPatterns = Aliases
+                .GroupBy(alias => alias.Full.Split('.').Last(), alias => alias.Alias)
+                .Select(group =>
+                    (new Regex(
+                        $@"(?<![A-Za-z0-9_]){Regex.Escape(group.Key)}(?![A-Za-z0-9_])"),
+                     group.First()))
+                .ToArray();
+
+        /// <summary>
+        /// Gets the shared stateless default provider.
+        /// </summary>
+        public static DefaultAliasProvider Instance { get; } = new DefaultAliasProvider();
+
+        private DefaultAliasProvider()
+        {
+        }
+
+        /// <inheritdoc />
+        public string ApplyAliases(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            foreach (var (pattern, alias) in FullTokenPatterns)
+            {
+                value = pattern.Replace(value, alias);
+            }
+
+            foreach (var (pattern, alias) in ShortTokenPatterns)
+            {
+                value = pattern.Replace(value, alias);
+            }
+
+            return value;
+        }
+    }
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Aliasing/IAliasProvider.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Aliasing/IAliasProvider.cs
@@ -1,0 +1,15 @@
+namespace Xml2Doc.Core.Aliasing
+{
+    /// <summary>
+    /// Applies display aliases to type tokens used in signatures, labels, and anchors.
+    /// </summary>
+    public interface IAliasProvider
+    {
+        /// <summary>
+        /// Applies aliases to complete type tokens without modifying partial identifiers.
+        /// </summary>
+        /// <param name="value">The signature, label, or documentation identifier to transform.</param>
+        /// <returns>The transformed value.</returns>
+        string ApplyAliases(string value);
+    }
+}

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -421,7 +421,7 @@ public sealed class MarkdownRenderer
             sb.AppendLine(BuildMemberToc(members));
         }
 
-        static string GroupKey(XMember mm)
+        string GroupKey(XMember mm)
         {
             var id = mm.Id;
             var parenIdx = id.IndexOf('(');

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Xml2Doc.Core.Models;
 using Xml2Doc.Core.Linking;
 using Xml2Doc.Core.OutputLifecycle;
+using Xml2Doc.Core.Aliasing;
 using System.Globalization;
 
 namespace Xml2Doc.Core;
@@ -45,6 +46,7 @@ public sealed class MarkdownRenderer
         new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
     private readonly Models.Xml2Doc _model;
     private readonly RendererOptions _opt;
+    private readonly IAliasProvider _aliasProvider;
 
     /// <summary>
     /// Internal link target selection mode for cref resolution (multi‑file vs single‑file).
@@ -89,6 +91,7 @@ public sealed class MarkdownRenderer
     {
         _model = model;
         _opt = options ?? new RendererOptions();
+        _aliasProvider = _opt.AliasProvider ?? DefaultAliasProvider.Instance;
         _linkResolver = new DefaultLinkResolver(
             labelFromCref: ShortLabelFromCref,
             idToAnchor: IdToAnchor,
@@ -432,7 +435,7 @@ public sealed class MarkdownRenderer
                 return $"<{string.Join(",", Enumerable.Range(1, n).Select(i => $"T{i}"))}>";
             });
 
-            nameAndParams = ApplyAliases(nameAndParams);
+            nameAndParams = _aliasProvider.ApplyAliases(nameAndParams);
             if (nameAndParams.StartsWith("System.", StringComparison.Ordinal))
                 nameAndParams = nameAndParams.Substring("System.".Length);
 
@@ -730,43 +733,9 @@ public sealed class MarkdownRenderer
     }
 
     /// <summary>
-    /// Built‑in mappings from fully‑qualified BCL types to C# aliases.
-    /// </summary>
-    private static readonly (string Full, string Alias)[] Aliases = new[]
-    {
-        ("System.String","string"), ("System.Int32","int"), ("System.Boolean","bool"),
-        ("System.Object","object"), ("System.Void","void"), ("System.Int64","long"),
-        ("System.Int16","short"), ("System.Byte","byte"), ("System.SByte","sbyte"),
-        ("System.UInt32","uint"), ("System.UInt64","ulong"), ("System.UInt16","ushort"),
-        ("System.Char","char"), ("System.Decimal","decimal"),
-        ("System.Double","double"), ("System.Single","float")
-    };
-
-    // Token‑aware full and short patterns (avoid partial replacements inside larger identifiers).
-    private static readonly (Regex Pattern, string Alias)[] AliasFullTokenPatterns =
-        Aliases.Select(a => (Pattern: new Regex($@"(?<![A-Za-z0-9_]){Regex.Escape(a.Full)}(?![A-Za-z0-9_])"), a.Alias)).ToArray();
-
-    private static readonly (Regex Pattern, string Alias)[] AliasShortTokenPatterns =
-        Aliases
-            .GroupBy(a => a.Full.Split('.').Last(), a => a.Alias)
-            .Select(g => (Pattern: new Regex($@"(?<![A-Za-z0-9_]){Regex.Escape(g.Key)}(?![A-Za-z0-9_])"), Alias: g.First()))
-            .ToArray();
-
-    /// <summary>
-    /// Applies alias substitutions to framework type tokens without touching longer identifiers.
-    /// </summary>
-    private static string ApplyAliases(string s)
-    {
-        if (string.IsNullOrEmpty(s)) return s;
-        foreach (var (pattern, alias) in AliasFullTokenPatterns) s = pattern.Replace(s, alias);
-        foreach (var (pattern, alias) in AliasShortTokenPatterns) s = pattern.Replace(s, alias);
-        return s;
-    }
-
-    /// <summary>
     /// Shortens a fully‑qualified type for signature display (aliases + recursive generic argument formatting).
     /// </summary>
-    private static string ShortenSignatureType(string full)
+    private string ShortenSignatureType(string full)
     {
         if (string.IsNullOrWhiteSpace(full)) return string.Empty;
 
@@ -777,7 +746,7 @@ public sealed class MarkdownRenderer
         var lt = s.IndexOf('<');
         if (lt < 0)
         {
-            s = ApplyAliases(s);
+            s = _aliasProvider.ApplyAliases(s);
             if (s.Contains('.')) s = s.Split('.').Last();
             s = s.Replace("System.", string.Empty);
             return s;
@@ -790,7 +759,7 @@ public sealed class MarkdownRenderer
         var inner = s.Substring(lt + 1, gt - lt - 1);
         var tail = s.Substring(gt + 1);
 
-        head = ApplyAliases(head);
+        head = _aliasProvider.ApplyAliases(head);
         if (head.Contains('.')) head = head.Split('.').Last();
         head = head.Replace("System.Collections.Generic.", string.Empty)
                    .Replace("System.", string.Empty);
@@ -953,8 +922,8 @@ public sealed class MarkdownRenderer
     /// <summary>
     /// Converts a documentation ID to a stable anchor (lowercase; generic braces → square brackets; aliases applied).
     /// </summary>
-    private static string IdToAnchor(string id) =>
-        ApplyAliases(id)
+    private string IdToAnchor(string id) =>
+        _aliasProvider.ApplyAliases(id)
             .Replace('{', '[')
             .Replace('}', ']')
             .ToLowerInvariant();
@@ -1000,7 +969,7 @@ public sealed class MarkdownRenderer
             return $"<{string.Join(",", Enumerable.Range(1, n).Select(i => $"T{i}"))}>";
         });
         last = last.Replace('{', '<').Replace('}', '>');
-        last = ApplyAliases(last);
+        last = _aliasProvider.ApplyAliases(last);
         return last;
     }
 
@@ -1082,7 +1051,7 @@ public sealed class MarkdownRenderer
             {
                 p = p.Trim();
                 p = p.Replace('{', '<').Replace('}', '>');
-                p = ApplyAliases(p);
+                p = _aliasProvider.ApplyAliases(p);
 
                 if (p.Contains('<') && p.Contains('>'))
                 {

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -13,6 +13,7 @@ Now multi-targeted and verified for consistent output across modern .NET TFMs.
 - Converts `<see>`, `<paramref>` into inline Markdown links and code spans.
 - Cleans namespaces and shortens generics (`List<T>` vs `System.Collections.Generic.List<T>`).
 - Built-in type aliasing (`System.String` → `string`, etc.) without breaking identifiers (`StringComparer` remains intact).
+- Optional `IAliasProvider` injection for consumer-defined signature, label, and anchor aliases.
 - Overload grouping for cleaner member sections.
 - Two output modes:
   - **Per-type** (`RenderToDirectory`) → `TypeName.md` with in-file member anchors.
@@ -90,6 +91,19 @@ renderer.RenderToDirectory("./docs");
 // Single-file output
 renderer.RenderToSingleFile("./docs/api.md");
 ````
+
+Custom aliasing is opt-in and uses the same provider for visible signatures, link labels, and member
+anchors so link targets remain aligned:
+
+```csharp
+using Xml2Doc.Core.Aliasing;
+
+var options = new RendererOptions(
+    AliasProvider: new MyAliasProvider());
+```
+
+Implement `IAliasProvider.ApplyAliases` with token-aware replacements. Omitting the provider uses
+`DefaultAliasProvider.Instance` and preserves the existing C# keyword mappings.
 
 ## Tests & Snapshots
 

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Xml2Doc.Core.Aliasing;
 
 namespace Xml2Doc.Core
 {
@@ -127,6 +128,10 @@ namespace Xml2Doc.Core
     /// Optional callback invoked for non-fatal rendering warnings, including unresolved
     /// <c>&lt;inheritdoc /&gt;</c> members.
     /// </param>
+    /// <param name="AliasProvider">
+    /// Optional alias provider. When omitted, <see cref="DefaultAliasProvider"/> preserves the
+    /// built-in C# keyword mappings.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -173,6 +178,7 @@ namespace Xml2Doc.Core
         bool PruneStaleFiles = false,
         string? ManifestIdentity = null,
         LineEndingStyle LineEndings = LineEndingStyle.Lf,
-        Action<string>? WarningSink = null
+        Action<string>? WarningSink = null,
+        IAliasProvider? AliasProvider = null
     );
 }

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -180,5 +180,53 @@ namespace Xml2Doc.Core
         LineEndingStyle LineEndings = LineEndingStyle.Lf,
         Action<string>? WarningSink = null,
         IAliasProvider? AliasProvider = null
-    );
+    )
+    {
+        /// <summary>
+        /// Preserves the constructor signature published before alias-provider injection was added.
+        /// </summary>
+        public RendererOptions(
+            FileNameMode FileNameMode,
+            string? RootNamespaceToTrim,
+            string CodeBlockLanguage,
+            bool TrimRootNamespaceInFileNames,
+            AnchorAlgorithm AnchorAlgorithm,
+            string? TemplatePath,
+            string? FrontMatterPath,
+            bool AutoLink,
+            string? AliasMapPath,
+            string? ExternalDocs,
+            bool EmitToc,
+            bool EmitNamespaceIndex,
+            bool BasenameOnly,
+            int? ParallelDegree,
+            bool GenerateIndex,
+            bool PruneStaleFiles,
+            string? ManifestIdentity,
+            LineEndingStyle LineEndings,
+            Action<string>? WarningSink)
+            : this(
+                FileNameMode,
+                RootNamespaceToTrim,
+                CodeBlockLanguage,
+                TrimRootNamespaceInFileNames,
+                AnchorAlgorithm,
+                TemplatePath,
+                FrontMatterPath,
+                AutoLink,
+                AliasMapPath,
+                ExternalDocs,
+                EmitToc,
+                EmitNamespaceIndex,
+                BasenameOnly,
+                ParallelDegree,
+                GenerateIndex,
+                PruneStaleFiles,
+                ManifestIdentity,
+                LineEndings,
+                WarningSink,
+                AliasProvider: null)
+        {
+        }
+    }
 }

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -1,4 +1,5 @@
 using Shouldly;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -20,6 +21,35 @@ public class AliasingTests
         DefaultAliasProvider.Instance
             .ApplyAliases("System.String StringComparer Int32 System.UInt32")
             .ShouldBe("string StringComparer int uint");
+    }
+
+    [Fact]
+    public void RendererOptions_PreservesPreviousConstructorSignature()
+    {
+        var parameterTypes = new[]
+        {
+            typeof(FileNameMode),
+            typeof(string),
+            typeof(string),
+            typeof(bool),
+            typeof(AnchorAlgorithm),
+            typeof(string),
+            typeof(string),
+            typeof(bool),
+            typeof(string),
+            typeof(string),
+            typeof(bool),
+            typeof(bool),
+            typeof(bool),
+            typeof(int?),
+            typeof(bool),
+            typeof(bool),
+            typeof(string),
+            typeof(LineEndingStyle),
+            typeof(Action<string>)
+        };
+
+        typeof(RendererOptions).GetConstructor(parameterTypes).ShouldNotBeNull();
     }
 
     [Fact]

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xml2Doc.Core;
+using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Sample;
 using Xunit;
 
@@ -12,6 +13,50 @@ public class AliasingTests
     // Resolve project directory from the test's bin folder
     private static string ProjectDir =>
         Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+
+    [Fact]
+    public void DefaultProvider_AppliesOnlyCompleteTypeTokens()
+    {
+        DefaultAliasProvider.Instance
+            .ApplyAliases("System.String StringComparer Int32 System.UInt32")
+            .ShouldBe("string StringComparer int uint");
+    }
+
+    [Fact]
+    public void CustomProvider_IsUsedForSignaturesLinksAndAnchors()
+    {
+        var xml = """
+            <doc><members>
+              <member name="T:Temp.Widget">
+                <summary>Calls <see cref="M:Temp.Widget.Run(System.Int32)"/>.</summary>
+              </member>
+              <member name="M:Temp.Widget.Run(System.Int32)">
+                <summary>Runs the widget.</summary>
+                <param name="value">Input value.</param>
+              </member>
+            </members></doc>
+            """;
+        var xmlPath = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(xmlPath, xml);
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+            var renderer = new MarkdownRenderer(
+                model,
+                new RendererOptions(AliasProvider: new IntegerAliasProvider()));
+
+            var markdown = renderer.RenderToString();
+
+            markdown.ShouldContain("[Run(integer)](#temp.widget.run(integer))");
+            markdown.ShouldContain("## Method: Run(integer)");
+            markdown.ShouldContain("<a id=\"temp.widget.run(integer)\"></a>");
+        }
+        finally
+        {
+            File.Delete(xmlPath);
+        }
+    }
 
     [Fact]
     public async Task TokenAwareAliasing_DoesNotCorruptIdentifiers()
@@ -60,5 +105,14 @@ public class AliasingTests
         Regex.IsMatch(mdNoAnchors, pattern).ShouldBeTrue(
             "Expected Mix(string, int, uint) signature (header or bullet) with aliases applied."
         );
+    }
+
+    private sealed class IntegerAliasProvider : IAliasProvider
+    {
+        public string ApplyAliases(string value) =>
+            Regex.Replace(
+                value,
+                @"(?<![A-Za-z0-9_])(?:System\.Int32|Int32)(?![A-Za-z0-9_])",
+                "integer");
     }
 }

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -48,7 +48,7 @@ public class AliasingTests
 
             var markdown = renderer.RenderToString();
 
-            markdown.ShouldContain("[Run(integer)](#temp.widget.run(integer))");
+            markdown.ShouldContain("[Run(integer)](Temp.Widget.md#temp.widget.run(integer))");
             markdown.ShouldContain("## Method: Run(integer)");
             markdown.ShouldContain("<a id=\"temp.widget.run(integer)\"></a>");
         }


### PR DESCRIPTION
## Summary

- introduce a public `IAliasProvider` abstraction and token-aware `DefaultAliasProvider`
- allow consumers to inject a custom provider through `RendererOptions`
- apply aliases consistently to signatures, link labels, links, and member anchors
- preserve the current default C# keyword aliases while avoiding partial identifier replacement
- add regression coverage for default and custom providers
- document custom alias-provider usage

## Why

Aliasing was hard-coded inside `MarkdownRenderer`, which prevented consumers from customizing mappings and coupled rendered signatures and anchors to renderer internals.

## Compatibility

When `AliasProvider` is omitted, `DefaultAliasProvider.Instance` preserves the existing built-in behavior. The new optional argument is appended to `RendererOptions`.

## Validation

- `git diff --check`
- verified the branch differs from `main` through the GitHub connector
- GitHub Actions will provide the authoritative .NET validation because the local workspace does not include the .NET SDK

Closes #37
Refs #43