### PR TITLE
Extract configurable anchor generator

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/Anchoring/DefaultAnchorGenerator.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Anchoring/DefaultAnchorGenerator.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xml2Doc.Core.Aliasing;
+
+namespace Xml2Doc.Core.Anchoring;
+
+/// <summary>
+/// Implements Xml2Doc's built-in heading algorithms and member-anchor behavior.
+/// </summary>
+public sealed class DefaultAnchorGenerator : IAnchorGenerator
+{
+    private readonly AnchorAlgorithm _algorithm;
+    private readonly IAliasProvider _aliasProvider;
+
+    /// <summary>Creates a built-in anchor generator.</summary>
+    public DefaultAnchorGenerator(
+        AnchorAlgorithm algorithm,
+        IAliasProvider? aliasProvider = null)
+    {
+        if (!Enum.IsDefined(typeof(AnchorAlgorithm), algorithm))
+            throw new ArgumentOutOfRangeException(nameof(algorithm));
+
+        _algorithm = algorithm;
+        _aliasProvider = aliasProvider ?? DefaultAliasProvider.Instance;
+    }
+
+    /// <inheritdoc />
+    public string GenerateHeadingAnchor(string heading)
+    {
+        if (heading is null)
+            throw new ArgumentNullException(nameof(heading));
+
+        return _algorithm switch
+        {
+            AnchorAlgorithm.Github => GithubSlug(heading),
+            AnchorAlgorithm.Kramdown => KramdownSlug(heading),
+            AnchorAlgorithm.Gfm => GfmSlug(heading),
+            _ => DefaultSlug(heading)
+        };
+    }
+
+    /// <inheritdoc />
+    public string GenerateMemberAnchor(string memberId)
+    {
+        if (memberId is null)
+            throw new ArgumentNullException(nameof(memberId));
+
+        return _aliasProvider.ApplyAliases(memberId)
+            .Replace('{', '[')
+            .Replace('}', ']')
+            .ToLowerInvariant();
+    }
+
+    private static string DefaultSlug(string heading)
+    {
+        var value = heading.Trim().ToLowerInvariant();
+        value = Regex.Replace(value, @"\s+", "-");
+        value = Regex.Replace(value, @"[^a-z0-9\-]", "");
+        return Regex.Replace(value, @"\-{2,}", "-").Trim('-');
+    }
+
+    private static string GithubSlug(string heading)
+    {
+        var value = RemoveDiacritics(heading).ToLowerInvariant();
+        value = Regex.Replace(value, @"[^a-z0-9\s\-]", " ");
+        value = Regex.Replace(value, @"\s+", "-");
+        return Regex.Replace(value, @"\-{2,}", "-").Trim('-');
+    }
+
+    private static string KramdownSlug(string heading)
+    {
+        var value = RemoveDiacritics(heading).ToLowerInvariant();
+        value = Regex.Replace(value, @"[^\w\s\-]", " ");
+        value = Regex.Replace(value, @"\s+", "-");
+        return Regex.Replace(value, @"\-{2,}", "-").Trim('-');
+    }
+
+    private static string GfmSlug(string heading)
+    {
+        var value = heading.Trim().ToLowerInvariant();
+        value = Regex.Replace(value, @"[^a-z0-9\-_.\s]", "");
+        value = Regex.Replace(value, @"\s+", "-");
+        return Regex.Replace(value, @"\-{2,}", "-").Trim('-');
+    }
+
+    private static string RemoveDiacritics(string value)
+    {
+        var formD = value.Normalize(NormalizationForm.FormD);
+        var builder = new StringBuilder(formD.Length);
+
+        foreach (var character in formD)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(character) !=
+                UnicodeCategory.NonSpacingMark)
+            {
+                builder.Append(character);
+            }
+        }
+
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Anchoring/DefaultAnchorGenerator.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Anchoring/DefaultAnchorGenerator.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Xml2Doc.Core.Aliasing;
@@ -89,13 +90,12 @@ public sealed class DefaultAnchorGenerator : IAnchorGenerator
         var formD = value.Normalize(NormalizationForm.FormD);
         var builder = new StringBuilder(formD.Length);
 
-        foreach (var character in formD)
+        foreach (var character in formD.Where(
+                     character =>
+                         CharUnicodeInfo.GetUnicodeCategory(character) !=
+                         UnicodeCategory.NonSpacingMark))
         {
-            if (CharUnicodeInfo.GetUnicodeCategory(character) !=
-                UnicodeCategory.NonSpacingMark)
-            {
-                builder.Append(character);
-            }
+            builder.Append(character);
         }
 
         return builder.ToString().Normalize(NormalizationForm.FormC);

--- a/Xml2Doc/src/Xml2Doc.Core/Anchoring/DefaultAnchorGenerator.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Anchoring/DefaultAnchorGenerator.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Xml2Doc.Core.Aliasing;
@@ -88,16 +86,10 @@ public sealed class DefaultAnchorGenerator : IAnchorGenerator
     private static string RemoveDiacritics(string value)
     {
         var formD = value.Normalize(NormalizationForm.FormD);
-        var builder = new StringBuilder(formD.Length);
-
-        foreach (var character in formD.Where(
-                     character =>
-                         CharUnicodeInfo.GetUnicodeCategory(character) !=
-                         UnicodeCategory.NonSpacingMark))
-        {
-            builder.Append(character);
-        }
-
-        return builder.ToString().Normalize(NormalizationForm.FormC);
+        var withoutDiacritics = Regex.Replace(
+            formD,
+            @"\p{Mn}",
+            string.Empty);
+        return withoutDiacritics.Normalize(NormalizationForm.FormC);
     }
 }

--- a/Xml2Doc/src/Xml2Doc.Core/Anchoring/IAnchorGenerator.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Anchoring/IAnchorGenerator.cs
@@ -1,0 +1,13 @@
+namespace Xml2Doc.Core.Anchoring;
+
+/// <summary>
+/// Generates stable anchors for headings and documented members.
+/// </summary>
+public interface IAnchorGenerator
+{
+    /// <summary>Generates an anchor for a rendered heading.</summary>
+    string GenerateHeadingAnchor(string heading);
+
+    /// <summary>Generates an anchor for an XML documentation member identifier.</summary>
+    string GenerateMemberAnchor(string memberId);
+}

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -9,7 +9,7 @@ using Xml2Doc.Core.Models;
 using Xml2Doc.Core.Linking;
 using Xml2Doc.Core.OutputLifecycle;
 using Xml2Doc.Core.Aliasing;
-using System.Globalization;
+using Xml2Doc.Core.Anchoring;
 
 namespace Xml2Doc.Core;
 
@@ -47,6 +47,7 @@ public sealed class MarkdownRenderer
     private readonly Models.Xml2Doc _model;
     private readonly RendererOptions _opt;
     private readonly IAliasProvider _aliasProvider;
+    private readonly IAnchorGenerator _anchorGenerator;
 
     /// <summary>
     /// Internal link target selection mode for cref resolution (multi‑file vs single‑file).
@@ -58,31 +59,6 @@ public sealed class MarkdownRenderer
     private bool _singleFileMode;
 
     /// <summary>
-    /// Precompiled whitespace matching regex (reserved for future slug optimizations).
-    /// </summary>
-    private static readonly Regex Spaces = new Regex(@"\s+", RegexOptions.Compiled);
-
-    /// <summary>
-    /// Precompiled pattern for GitHub slug punctuation removal (currently unused; kept for potential micro‑optimization).
-    /// </summary>
-    private static readonly Regex GitHubDrop = new Regex(@"[^a-z0-9\- ]+", RegexOptions.Compiled);
-
-    /// <summary>
-    /// Precompiled pattern for Kramdown slug punctuation removal (unused placeholder).
-    /// </summary>
-    private static readonly Regex KramdownDrop = new Regex(@"[^a-z0-9\- _:.]+", RegexOptions.Compiled);
-
-    /// <summary>
-    /// Precompiled pattern for GFM slug punctuation removal (unused placeholder).
-    /// </summary>
-    private static readonly Regex GfmDrop = new Regex(@"[^a-z0-9\-_. ]+", RegexOptions.Compiled);
-
-    /// <summary>
-    /// Collapses consecutive dashes to a single dash (unused placeholder for potential manual slug pipelines).
-    /// </summary>
-    private static readonly Regex CollapseDash = new Regex(@"\-+", RegexOptions.Compiled);
-
-    /// <summary>
     /// Creates a renderer for a parsed XML documentation model.
     /// </summary>
     /// <param name="model">Parsed XML documentation model (never null).</param>
@@ -92,6 +68,8 @@ public sealed class MarkdownRenderer
         _model = model;
         _opt = options ?? new RendererOptions();
         _aliasProvider = _opt.AliasProvider ?? DefaultAliasProvider.Instance;
+        _anchorGenerator = _opt.AnchorGenerator ??
+            new DefaultAnchorGenerator(_opt.AnchorAlgorithm, _aliasProvider);
         _linkResolver = new DefaultLinkResolver(
             labelFromCref: ShortLabelFromCref,
             idToAnchor: IdToAnchor,
@@ -558,83 +536,8 @@ public sealed class MarkdownRenderer
     /// </summary>
     /// <param name="heading">Raw heading text.</param>
     /// <returns>Algorithm-specific slug string.</returns>
-    private string HeadingSlug(string heading)
-    {
-        switch (_opt.AnchorAlgorithm)
-        {
-            case AnchorAlgorithm.Github:
-                return GithubSlug(heading);
-            case AnchorAlgorithm.Kramdown:
-                return KramdownSlug(heading);
-            case AnchorAlgorithm.Gfm:
-                return GfmSlug(heading);
-            case AnchorAlgorithm.Default:
-            default:
-                return DefaultSlug(heading);
-        }
-    }
-
-    /// <summary>
-    /// Default slug (lowercase, whitespace → single dash, strip non <c>[a-z0-9-]</c>, collapse multi‑dash runs, trim dashes).
-    /// </summary>
-    private static string DefaultSlug(string heading)
-    {
-        var s = heading.Trim().ToLowerInvariant();
-        s = Regex.Replace(s, @"\s+", "-");
-        s = Regex.Replace(s, @"[^a-z0-9\-]", "");
-        s = Regex.Replace(s, @"\-{2,}", "-").Trim('-');
-        return s;
-    }
-
-    /// <summary>
-    /// GitHub-style slug: Unicode normalize + diacritic removal, lowercase, drop punctuation, collapse spaces to dashes, trim.
-    /// </summary>
-    private static string GithubSlug(string heading)
-    {
-        var formD = heading.Normalize(NormalizationForm.FormD);
-        var sb = new StringBuilder(formD.Length);
-        foreach (var ch in formD)
-        {
-            if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark)
-                sb.Append(ch);
-        }
-        var s = sb.ToString().Normalize(NormalizationForm.FormC).ToLowerInvariant();
-        s = Regex.Replace(s, @"[^a-z0-9\s\-]", " ");
-        s = Regex.Replace(s, @"\s+", "-");
-        s = Regex.Replace(s, @"\-{2,}", "-").Trim('-');
-        return s;
-    }
-
-    /// <summary>
-    /// Kramdown/Jekyll slug: diacritics removed, lowercase, punctuation stripped (except underscore), whitespace → dash, trim.
-    /// </summary>
-    private static string KramdownSlug(string heading)
-    {
-        var formD = heading.Normalize(NormalizationForm.FormD);
-        var sb = new StringBuilder(formD.Length);
-        foreach (var ch in formD)
-        {
-            if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark)
-                sb.Append(ch);
-        }
-        var s = sb.ToString().Normalize(NormalizationForm.FormC).ToLowerInvariant();
-        s = Regex.Replace(s, @"[^\w\s\-]", " ");
-        s = Regex.Replace(s, @"\s+", "-");
-        s = Regex.Replace(s, @"\-{2,}", "-").Trim('-');
-        return s;
-    }
-
-    /// <summary>
-    /// GFM slug variant: lowercase, retain underscore and dot, remove other punctuation, whitespace becomes dash, collapse dashes, trim.
-    /// </summary>
-    private static string GfmSlug(string heading)
-    {
-        var s = heading.Trim().ToLowerInvariant();
-        s = Regex.Replace(s, @"[^a-z0-9\-_.\s]", "");
-        s = Regex.Replace(s, @"\s+", "-");
-        s = Regex.Replace(s, @"\-{2,}", "-").Trim('-');
-        return s;
-    }
+    private string HeadingSlug(string heading) =>
+        _anchorGenerator.GenerateHeadingAnchor(heading);
 
     /// <summary>
     /// Builds a concise member header (Kind + simplified signature) for headings and overload bullets.
@@ -923,10 +826,7 @@ public sealed class MarkdownRenderer
     /// Converts a documentation ID to a stable anchor (lowercase; generic braces → square brackets; aliases applied).
     /// </summary>
     private string IdToAnchor(string id) =>
-        _aliasProvider.ApplyAliases(id)
-            .Replace('{', '[')
-            .Replace('}', ']')
-            .ToLowerInvariant();
+        _anchorGenerator.GenerateMemberAnchor(id);
 
     /// <summary>
     /// Converts a <c>&lt;seealso&gt;</c> element to Markdown (cref, href, or inner text).

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -105,6 +105,20 @@ var options = new RendererOptions(
 Implement `IAliasProvider.ApplyAliases` with token-aware replacements. Omitting the provider uses
 `DefaultAliasProvider.Instance` and preserves the existing C# keyword mappings.
 
+Anchor generation is also replaceable while the built-in `AnchorAlgorithm` values remain the
+default:
+
+```csharp
+using Xml2Doc.Core.Anchoring;
+
+var options = new RendererOptions(
+    AnchorGenerator: new MyAnchorGenerator());
+```
+
+Implement both `GenerateHeadingAnchor` and `GenerateMemberAnchor`. Xml2Doc uses the selected
+provider for emitted anchors and internal link targets, keeping them aligned in per-type and
+single-file output.
+
 ## Tests & Snapshots
 
 - Snapshot tests assert stable Markdown for representative inputs.

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Xml2Doc.Core.Aliasing;
+using Xml2Doc.Core.Anchoring;
 
 namespace Xml2Doc.Core
 {
@@ -132,6 +133,10 @@ namespace Xml2Doc.Core
     /// Optional alias provider. When omitted, <see cref="DefaultAliasProvider"/> preserves the
     /// built-in C# keyword mappings.
     /// </param>
+    /// <param name="AnchorGenerator">
+    /// Optional anchor generator. When omitted, the selected <paramref name="AnchorAlgorithm"/>
+    /// uses Xml2Doc's built-in implementation.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -179,9 +184,59 @@ namespace Xml2Doc.Core
         string? ManifestIdentity = null,
         LineEndingStyle LineEndings = LineEndingStyle.Lf,
         Action<string>? WarningSink = null,
-        IAliasProvider? AliasProvider = null
+        IAliasProvider? AliasProvider = null,
+        IAnchorGenerator? AnchorGenerator = null
     )
     {
+        /// <summary>
+        /// Preserves the constructor signature published with alias-provider injection.
+        /// </summary>
+        public RendererOptions(
+            FileNameMode FileNameMode,
+            string? RootNamespaceToTrim,
+            string CodeBlockLanguage,
+            bool TrimRootNamespaceInFileNames,
+            AnchorAlgorithm AnchorAlgorithm,
+            string? TemplatePath,
+            string? FrontMatterPath,
+            bool AutoLink,
+            string? AliasMapPath,
+            string? ExternalDocs,
+            bool EmitToc,
+            bool EmitNamespaceIndex,
+            bool BasenameOnly,
+            int? ParallelDegree,
+            bool GenerateIndex,
+            bool PruneStaleFiles,
+            string? ManifestIdentity,
+            LineEndingStyle LineEndings,
+            Action<string>? WarningSink,
+            IAliasProvider? AliasProvider)
+            : this(
+                FileNameMode,
+                RootNamespaceToTrim,
+                CodeBlockLanguage,
+                TrimRootNamespaceInFileNames,
+                AnchorAlgorithm,
+                TemplatePath,
+                FrontMatterPath,
+                AutoLink,
+                AliasMapPath,
+                ExternalDocs,
+                EmitToc,
+                EmitNamespaceIndex,
+                BasenameOnly,
+                ParallelDegree,
+                GenerateIndex,
+                PruneStaleFiles,
+                ManifestIdentity,
+                LineEndings,
+                WarningSink,
+                AliasProvider,
+                AnchorGenerator: null)
+        {
+        }
+
         /// <summary>
         /// Preserves the constructor signature published before alias-provider injection was added.
         /// </summary>
@@ -225,7 +280,8 @@ namespace Xml2Doc.Core
                 ManifestIdentity,
                 LineEndings,
                 WarningSink,
-                AliasProvider: null)
+                AliasProvider: null,
+                AnchorGenerator: null)
         {
         }
     }

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -50,6 +50,9 @@ public class AliasingTests
         };
 
         typeof(RendererOptions).GetConstructor(parameterTypes).ShouldNotBeNull();
+        typeof(RendererOptions)
+            .GetConstructor(parameterTypes.Concat(new[] { typeof(IAliasProvider) }).ToArray())
+            .ShouldNotBeNull();
     }
 
     [Fact]

--- a/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/RenderingParityMatrixTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Xml2Doc.Core;
+using Xml2Doc.Core.Anchoring;
 using Xunit;
 
 namespace Xml2Doc.Tests
@@ -18,6 +19,23 @@ namespace Xml2Doc.Tests
                 yield return new object[] { algorithm, false };
                 yield return new object[] { algorithm, true };
             }
+        }
+
+        [Theory]
+        [InlineData(AnchorAlgorithm.Default, "crme-brle-v20")]
+        [InlineData(AnchorAlgorithm.Github, "creme-brulee-v2-0")]
+        [InlineData(AnchorAlgorithm.Kramdown, "creme-brulee_-v2-0")]
+        [InlineData(AnchorAlgorithm.Gfm, "crme-brle_-v2.0")]
+        public void BuiltInAnchorGenerators_PreserveExistingHeadingSlugs(
+            AnchorAlgorithm algorithm,
+            string expected)
+        {
+            var generator = new DefaultAnchorGenerator(algorithm);
+
+            generator.GenerateHeadingAnchor("Crème brûlée_ v2.0!")
+                .ShouldBe(expected);
+            generator.GenerateMemberAnchor("Temp.Widget.Run(System.Int32)")
+                .ShouldBe("temp.widget.run(int)");
         }
 
         [Theory]
@@ -87,6 +105,45 @@ namespace Xml2Doc.Tests
             }
         }
 
+        [Fact]
+        public async Task CustomAnchorGenerator_IsUsedForEmittedAnchorsAndLinks()
+        {
+            var root = ChildPath(
+                ChildPath(Path.GetTempPath(), "Xml2Doc.Tests"),
+                Path.GetFileName(Path.GetRandomFileName()));
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                var xmlPath = ChildPath(root, "custom-anchors.xml");
+                await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
+                var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+                var renderer = new MarkdownRenderer(
+                    model,
+                    new RendererOptions(
+                        AnchorGenerator: new PrefixAnchorGenerator()));
+                var output = ChildPath(root, "api.md");
+
+                renderer.RenderToSingleFile(output);
+                var markdown = await ReadRequiredMarkdownAsync(output);
+
+                var typeHref = ExtractHref(markdown, "HTTP_Parser_v2");
+                typeHref.ShouldBe("#heading-http_parser_v2");
+                AssertAnchorExists(markdown, typeHref.Substring(1));
+
+                var memberHref = ExtractHref(markdown, "Do(string)");
+                memberHref.ShouldBe("#member-temp.http_parser_v2.do(system.string)");
+                AssertAnchorExists(markdown, memberHref.Substring(1));
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
+        }
+
         private static string ExtractHref(string markdown, string label)
         {
             var marker = $"[{label}](";
@@ -117,6 +174,15 @@ namespace Xml2Doc.Tests
 
         private static void AssertAnchorExists(string markdown, string anchor) =>
             markdown.ShouldContain($"<a id=\"{anchor}\"></a>");
+
+        private sealed class PrefixAnchorGenerator : IAnchorGenerator
+        {
+            public string GenerateHeadingAnchor(string heading) =>
+                "heading-" + heading.ToLowerInvariant();
+
+            public string GenerateMemberAnchor(string memberId) =>
+                "member-" + memberId.ToLowerInvariant();
+        }
 
         private static async Task<string> ReadRequiredMarkdownAsync(string path)
         {


### PR DESCRIPTION
## Summary

- introduce public `IAnchorGenerator` and built-in `DefaultAnchorGenerator`
- extract Default, GitHub, GFM, and Kramdown slug behavior from `MarkdownRenderer`
- use the selected generator consistently for emitted heading/member anchors and internal link targets
- allow consumers to inject a custom generator through `RendererOptions`
- preserve the previous 19- and 20-parameter `RendererOptions` constructor signatures
- add exact built-in parity tests and custom-generator integration coverage
- document custom anchor generation

## Why

Anchor generation was selected through `AnchorAlgorithm` but implemented directly inside `MarkdownRenderer`. Consumers could select built-in behavior but could not supply their own implementation.

## Compatibility

When `AnchorGenerator` is omitted, `DefaultAnchorGenerator` uses the existing `AnchorAlgorithm` and alias provider, preserving current heading and member anchors. Explicit compatibility constructors retain the previously published binary signatures.

## Validation

- `git diff --check`
- existing cross-mode/algorithm parity matrix retained
- new exact built-in behavior and custom-provider tests added
- GitHub Actions provides authoritative .NET validation because the local workspace has no .NET SDK

Closes #34
Refs #43