### PR TITLE
Add template and front matter rendering

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -80,6 +80,13 @@ public sealed class MarkdownRenderer
                 "TemplateRenderer cannot be combined with TemplatePath or FrontMatterPath.",
                 nameof(options));
         }
+        if (_opt.FrontMatter is not null &&
+            !string.IsNullOrWhiteSpace(_opt.FrontMatterPath))
+        {
+            throw new ArgumentException(
+                "FrontMatter cannot be combined with FrontMatterPath.",
+                nameof(options));
+        }
 
         _templateRenderer = _opt.TemplateRenderer ??
             (!string.IsNullOrWhiteSpace(_opt.TemplatePath) ||
@@ -208,7 +215,7 @@ public sealed class MarkdownRenderer
                     NormalizeLineEndings(ApplyTemplate(
                         nsIndex.ToString(),
                         "Namespaces",
-                        TemplateDocumentKind.Index)),
+                        TemplateDocumentKind.NamespaceOverview)),
                     MarkdownEncoding);
             }
 
@@ -340,8 +347,17 @@ public sealed class MarkdownRenderer
     private string ApplyTemplate(
         string content,
         string? title,
-        TemplateDocumentKind kind) =>
-        _templateRenderer.Render(new TemplateRenderContext(content, title, kind));
+        TemplateDocumentKind kind)
+    {
+        var context = new TemplateRenderContext(content, title, kind);
+        var rendered = _templateRenderer.Render(context);
+        var frontMatter = _opt.FrontMatter?.Invoke(context);
+
+        if (frontMatter is null || frontMatter.Count == 0)
+            return rendered;
+
+        return YamlFrontMatter.Serialize(frontMatter) + "\n" + rendered;
+    }
 
     // === Core rendering ===
 

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -10,6 +10,7 @@ using Xml2Doc.Core.Linking;
 using Xml2Doc.Core.OutputLifecycle;
 using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
+using Xml2Doc.Core.Templates;
 
 namespace Xml2Doc.Core;
 
@@ -48,6 +49,7 @@ public sealed class MarkdownRenderer
     private readonly RendererOptions _opt;
     private readonly IAliasProvider _aliasProvider;
     private readonly IAnchorGenerator _anchorGenerator;
+    private readonly ITemplateRenderer _templateRenderer;
 
     /// <summary>
     /// Internal link target selection mode for cref resolution (multi‑file vs single‑file).
@@ -70,6 +72,22 @@ public sealed class MarkdownRenderer
         _aliasProvider = _opt.AliasProvider ?? DefaultAliasProvider.Instance;
         _anchorGenerator = _opt.AnchorGenerator ??
             new DefaultAnchorGenerator(_opt.AnchorAlgorithm, _aliasProvider);
+        if (_opt.TemplateRenderer is not null &&
+            (!string.IsNullOrWhiteSpace(_opt.TemplatePath) ||
+             !string.IsNullOrWhiteSpace(_opt.FrontMatterPath)))
+        {
+            throw new ArgumentException(
+                "TemplateRenderer cannot be combined with TemplatePath or FrontMatterPath.",
+                nameof(options));
+        }
+
+        _templateRenderer = _opt.TemplateRenderer ??
+            (!string.IsNullOrWhiteSpace(_opt.TemplatePath) ||
+             !string.IsNullOrWhiteSpace(_opt.FrontMatterPath)
+                ? new FileTemplateRenderer(
+                    _opt.TemplatePath,
+                    _opt.FrontMatterPath)
+                : DefaultTemplateRenderer.Instance);
         _linkResolver = new DefaultLinkResolver(
             labelFromCref: ShortLabelFromCref,
             idToAnchor: IdToAnchor,
@@ -126,13 +144,19 @@ public sealed class MarkdownRenderer
                 var file = Path.Combine(outDir, FileNameForPerType(t.Id));
                 File.WriteAllText(
                     file,
-                    NormalizeLineEndings(RenderType(t, includeHeader: true)),
+                    NormalizeLineEndings(ApplyTemplate(
+                        RenderType(t, includeHeader: true),
+                        ShortTypeDisplay(t.Id),
+                        TemplateDocumentKind.Type)),
                     MarkdownEncoding);
             }
             if (_opt.GenerateIndex)
                 File.WriteAllText(
                     CombineOutputPath(outDir, "index.md"),
-                    NormalizeLineEndings(RenderIndex(types, useAnchors: false)),
+                    NormalizeLineEndings(ApplyTemplate(
+                        RenderIndex(types, useAnchors: false),
+                        "API Reference",
+                        TemplateDocumentKind.Index)),
                     MarkdownEncoding);
 
             if (_opt.EmitNamespaceIndex)
@@ -165,7 +189,10 @@ public sealed class MarkdownRenderer
                     }
                     File.WriteAllText(
                         nsFile,
-                        NormalizeLineEndings(sbNs.ToString()),
+                        NormalizeLineEndings(ApplyTemplate(
+                            sbNs.ToString(),
+                            ns,
+                            TemplateDocumentKind.NamespaceIndex)),
                         MarkdownEncoding);
                 }
 
@@ -178,7 +205,10 @@ public sealed class MarkdownRenderer
                 }
                 File.WriteAllText(
                     CombineOutputPath(outDir, "namespaces.md"),
-                    NormalizeLineEndings(nsIndex.ToString()),
+                    NormalizeLineEndings(ApplyTemplate(
+                        nsIndex.ToString(),
+                        "Namespaces",
+                        TemplateDocumentKind.Index)),
                     MarkdownEncoding);
             }
 
@@ -296,13 +326,22 @@ public sealed class MarkdownRenderer
                 }
             }
 
-            return sb.ToString();
+            return ApplyTemplate(
+                sb.ToString(),
+                "API Reference",
+                TemplateDocumentKind.SingleFile);
         }
         finally
         {
             _linkMode = prev;
         }
     }
+
+    private string ApplyTemplate(
+        string content,
+        string? title,
+        TemplateDocumentKind kind) =>
+        _templateRenderer.Render(new TemplateRenderContext(content, title, kind));
 
     // === Core rendering ===
 

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -119,6 +119,20 @@ Implement both `GenerateHeadingAnchor` and `GenerateMemberAnchor`. Xml2Doc uses 
 provider for emitted anchors and internal link targets, keeping them aligned in per-type and
 single-file output.
 
+Templates and front matter are optional. A file template must contain `{{content}}`; it may also
+use `{{title}}` and `{{kind}}`. Front matter is prepended verbatim, so include delimiters such as
+`---` in the front-matter file when targeting YAML-aware documentation systems:
+
+```csharp
+var options = new RendererOptions(
+    TemplatePath: "templates/page.md",
+    FrontMatterPath: "templates/front-matter.yml");
+```
+
+For programmatic layouts, implement `ITemplateRenderer.Render` and pass it through
+`TemplateRenderer`. Programmatic renderers cannot be combined with the file-based options.
+Omitting all template options preserves the built-in Markdown byte-for-byte.
+
 ## Tests & Snapshots
 
 - Snapshot tests assert stable Markdown for representative inputs.

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -133,6 +133,24 @@ For programmatic layouts, implement `ITemplateRenderer.Render` and pass it throu
 `TemplateRenderer`. Programmatic renderers cannot be combined with the file-based options.
 Omitting all template options preserves the built-in Markdown byte-for-byte.
 
+Per-document YAML can be generated with the `FrontMatter` delegate. The context identifies the
+document title and kind, including distinct `Index`, `NamespaceOverview`, `NamespaceIndex`,
+`Type`, and `SingleFile` values:
+
+```csharp
+var options = new RendererOptions(
+    FrontMatter: context => new Dictionary<string, object?>
+    {
+        ["title"] = context.Title,
+        ["kind"] = context.Kind.ToString(),
+        ["generated"] = true
+    });
+```
+
+Keys are ordered ordinally for deterministic output. Supported values include strings, booleans,
+numbers, dates, enums, nulls, and scalar sequences. The delegate cannot be combined with
+`FrontMatterPath`.
+
 ## Tests & Snapshots
 
 - Snapshot tests assert stable Markdown for representative inputs.

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -142,6 +142,10 @@ namespace Xml2Doc.Core
     /// Optional programmatic template renderer. Cannot be combined with
     /// <paramref name="TemplatePath"/> or <paramref name="FrontMatterPath"/>.
     /// </param>
+    /// <param name="FrontMatter">
+    /// Optional per-document metadata provider. Returned scalar values are serialized as
+    /// deterministic YAML front matter. Cannot be combined with <paramref name="FrontMatterPath"/>.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -191,9 +195,63 @@ namespace Xml2Doc.Core
         Action<string>? WarningSink = null,
         IAliasProvider? AliasProvider = null,
         IAnchorGenerator? AnchorGenerator = null,
-        ITemplateRenderer? TemplateRenderer = null
+        ITemplateRenderer? TemplateRenderer = null,
+        Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter = null
     )
     {
+        /// <summary>
+        /// Preserves the constructor signature published with template-renderer injection.
+        /// </summary>
+        public RendererOptions(
+            FileNameMode FileNameMode,
+            string? RootNamespaceToTrim,
+            string CodeBlockLanguage,
+            bool TrimRootNamespaceInFileNames,
+            AnchorAlgorithm AnchorAlgorithm,
+            string? TemplatePath,
+            string? FrontMatterPath,
+            bool AutoLink,
+            string? AliasMapPath,
+            string? ExternalDocs,
+            bool EmitToc,
+            bool EmitNamespaceIndex,
+            bool BasenameOnly,
+            int? ParallelDegree,
+            bool GenerateIndex,
+            bool PruneStaleFiles,
+            string? ManifestIdentity,
+            LineEndingStyle LineEndings,
+            Action<string>? WarningSink,
+            IAliasProvider? AliasProvider,
+            IAnchorGenerator? AnchorGenerator,
+            ITemplateRenderer? TemplateRenderer)
+            : this(
+                FileNameMode,
+                RootNamespaceToTrim,
+                CodeBlockLanguage,
+                TrimRootNamespaceInFileNames,
+                AnchorAlgorithm,
+                TemplatePath,
+                FrontMatterPath,
+                AutoLink,
+                AliasMapPath,
+                ExternalDocs,
+                EmitToc,
+                EmitNamespaceIndex,
+                BasenameOnly,
+                ParallelDegree,
+                GenerateIndex,
+                PruneStaleFiles,
+                ManifestIdentity,
+                LineEndings,
+                WarningSink,
+                AliasProvider,
+                AnchorGenerator,
+                TemplateRenderer,
+                FrontMatter: null)
+        {
+        }
+
         /// <summary>
         /// Preserves the constructor signature published with anchor-generator injection.
         /// </summary>
@@ -241,7 +299,8 @@ namespace Xml2Doc.Core
                 WarningSink,
                 AliasProvider,
                 AnchorGenerator,
-                TemplateRenderer: null)
+                TemplateRenderer: null,
+                FrontMatter: null)
         {
         }
 
@@ -291,7 +350,8 @@ namespace Xml2Doc.Core
                 WarningSink,
                 AliasProvider,
                 AnchorGenerator: null,
-                TemplateRenderer: null)
+                TemplateRenderer: null,
+                FrontMatter: null)
         {
         }
 
@@ -340,7 +400,8 @@ namespace Xml2Doc.Core
                 WarningSink,
                 AliasProvider: null,
                 AnchorGenerator: null,
-                TemplateRenderer: null)
+                TemplateRenderer: null,
+                FrontMatter: null)
         {
         }
     }

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
+using Xml2Doc.Core.Templates;
 
 namespace Xml2Doc.Core
 {
@@ -137,6 +138,10 @@ namespace Xml2Doc.Core
     /// Optional anchor generator. When omitted, the selected <paramref name="AnchorAlgorithm"/>
     /// uses Xml2Doc's built-in implementation.
     /// </param>
+    /// <param name="TemplateRenderer">
+    /// Optional programmatic template renderer. Cannot be combined with
+    /// <paramref name="TemplatePath"/> or <paramref name="FrontMatterPath"/>.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -185,9 +190,61 @@ namespace Xml2Doc.Core
         LineEndingStyle LineEndings = LineEndingStyle.Lf,
         Action<string>? WarningSink = null,
         IAliasProvider? AliasProvider = null,
-        IAnchorGenerator? AnchorGenerator = null
+        IAnchorGenerator? AnchorGenerator = null,
+        ITemplateRenderer? TemplateRenderer = null
     )
     {
+        /// <summary>
+        /// Preserves the constructor signature published with anchor-generator injection.
+        /// </summary>
+        public RendererOptions(
+            FileNameMode FileNameMode,
+            string? RootNamespaceToTrim,
+            string CodeBlockLanguage,
+            bool TrimRootNamespaceInFileNames,
+            AnchorAlgorithm AnchorAlgorithm,
+            string? TemplatePath,
+            string? FrontMatterPath,
+            bool AutoLink,
+            string? AliasMapPath,
+            string? ExternalDocs,
+            bool EmitToc,
+            bool EmitNamespaceIndex,
+            bool BasenameOnly,
+            int? ParallelDegree,
+            bool GenerateIndex,
+            bool PruneStaleFiles,
+            string? ManifestIdentity,
+            LineEndingStyle LineEndings,
+            Action<string>? WarningSink,
+            IAliasProvider? AliasProvider,
+            IAnchorGenerator? AnchorGenerator)
+            : this(
+                FileNameMode,
+                RootNamespaceToTrim,
+                CodeBlockLanguage,
+                TrimRootNamespaceInFileNames,
+                AnchorAlgorithm,
+                TemplatePath,
+                FrontMatterPath,
+                AutoLink,
+                AliasMapPath,
+                ExternalDocs,
+                EmitToc,
+                EmitNamespaceIndex,
+                BasenameOnly,
+                ParallelDegree,
+                GenerateIndex,
+                PruneStaleFiles,
+                ManifestIdentity,
+                LineEndings,
+                WarningSink,
+                AliasProvider,
+                AnchorGenerator,
+                TemplateRenderer: null)
+        {
+        }
+
         /// <summary>
         /// Preserves the constructor signature published with alias-provider injection.
         /// </summary>
@@ -233,7 +290,8 @@ namespace Xml2Doc.Core
                 LineEndings,
                 WarningSink,
                 AliasProvider,
-                AnchorGenerator: null)
+                AnchorGenerator: null,
+                TemplateRenderer: null)
         {
         }
 
@@ -281,7 +339,8 @@ namespace Xml2Doc.Core
                 LineEndings,
                 WarningSink,
                 AliasProvider: null,
-                AnchorGenerator: null)
+                AnchorGenerator: null,
+                TemplateRenderer: null)
         {
         }
     }

--- a/Xml2Doc/src/Xml2Doc.Core/Templates/DefaultTemplateRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Templates/DefaultTemplateRenderer.cs
@@ -1,0 +1,21 @@
+namespace Xml2Doc.Core.Templates;
+
+/// <summary>Preserves Xml2Doc's built-in Markdown without modification.</summary>
+public sealed class DefaultTemplateRenderer : ITemplateRenderer
+{
+    /// <summary>The shared stateless instance.</summary>
+    public static DefaultTemplateRenderer Instance { get; } = new();
+
+    private DefaultTemplateRenderer()
+    {
+    }
+
+    /// <inheritdoc />
+    public string Render(TemplateRenderContext context)
+    {
+        if (context is null)
+            throw new ArgumentNullException(nameof(context));
+
+        return context.Content;
+    }
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Templates/FileTemplateRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Templates/FileTemplateRenderer.cs
@@ -1,0 +1,60 @@
+namespace Xml2Doc.Core.Templates;
+
+/// <summary>
+/// Applies an optional token-based template and optional front-matter file.
+/// </summary>
+public sealed class FileTemplateRenderer : ITemplateRenderer
+{
+    private const string ContentToken = "{{content}}";
+    private readonly string? _template;
+    private readonly string? _frontMatter;
+
+    /// <summary>Loads the configured files once for deterministic rendering.</summary>
+    public FileTemplateRenderer(
+        string? templatePath,
+        string? frontMatterPath)
+    {
+        if (string.IsNullOrWhiteSpace(templatePath) &&
+            string.IsNullOrWhiteSpace(frontMatterPath))
+        {
+            throw new ArgumentException(
+                "A template path or front-matter path is required.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(templatePath))
+        {
+            _template = File.ReadAllText(templatePath!);
+            if (_template.IndexOf(ContentToken, StringComparison.Ordinal) < 0)
+            {
+                throw new InvalidDataException(
+                    $"Template '{templatePath}' must contain {ContentToken}.");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(frontMatterPath))
+            _frontMatter = File.ReadAllText(frontMatterPath!);
+    }
+
+    /// <inheritdoc />
+    public string Render(TemplateRenderContext context)
+    {
+        if (context is null)
+            throw new ArgumentNullException(nameof(context));
+
+        var content = context.Content;
+        if (_template is not null)
+        {
+            content = _template
+                .Replace("{{title}}", context.Title ?? string.Empty)
+                .Replace(
+                    "{{kind}}",
+                    context.Kind.ToString().ToLowerInvariant())
+                .Replace(ContentToken, content);
+        }
+
+        if (_frontMatter is null)
+            return content;
+
+        return _frontMatter.TrimEnd('\r', '\n') + "\n" + content;
+    }
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Templates/ITemplateRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Templates/ITemplateRenderer.cs
@@ -1,0 +1,8 @@
+namespace Xml2Doc.Core.Templates;
+
+/// <summary>Applies an outer layout or front matter to generated Markdown.</summary>
+public interface ITemplateRenderer
+{
+    /// <summary>Transforms one complete built-in Markdown document.</summary>
+    string Render(TemplateRenderContext context);
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Templates/TemplateDocumentKind.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Templates/TemplateDocumentKind.cs
@@ -1,0 +1,17 @@
+namespace Xml2Doc.Core.Templates;
+
+/// <summary>Identifies the kind of Markdown document being templated.</summary>
+public enum TemplateDocumentKind
+{
+    /// <summary>A generated page for one documented type.</summary>
+    Type,
+
+    /// <summary>The primary API index.</summary>
+    Index,
+
+    /// <summary>A namespace-specific index.</summary>
+    NamespaceIndex,
+
+    /// <summary>A consolidated single-file API document.</summary>
+    SingleFile
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Templates/TemplateDocumentKind.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Templates/TemplateDocumentKind.cs
@@ -12,6 +12,9 @@ public enum TemplateDocumentKind
     /// <summary>A namespace-specific index.</summary>
     NamespaceIndex,
 
+    /// <summary>The overview that links to every namespace index.</summary>
+    NamespaceOverview,
+
     /// <summary>A consolidated single-file API document.</summary>
     SingleFile
 }

--- a/Xml2Doc/src/Xml2Doc.Core/Templates/TemplateRenderContext.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Templates/TemplateRenderContext.cs
@@ -1,0 +1,10 @@
+namespace Xml2Doc.Core.Templates;
+
+/// <summary>Describes a rendered Markdown document before template application.</summary>
+/// <param name="Content">The complete built-in Markdown content.</param>
+/// <param name="Title">The document title, when available.</param>
+/// <param name="Kind">The kind of generated document.</param>
+public sealed record TemplateRenderContext(
+    string Content,
+    string? Title,
+    TemplateDocumentKind Kind);

--- a/Xml2Doc/src/Xml2Doc.Core/Templates/YamlFrontMatter.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Templates/YamlFrontMatter.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Xml2Doc.Core.Templates;
+
+internal static class YamlFrontMatter
+{
+    internal static string Serialize(
+        IReadOnlyDictionary<string, object?> values)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("---");
+
+        foreach (var pair in values.OrderBy(
+                     pair => pair.Key,
+                     StringComparer.Ordinal))
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+                throw new ArgumentException("Front-matter keys cannot be empty.");
+
+            builder
+                .Append(FormatKey(pair.Key))
+                .Append(": ")
+                .AppendLine(FormatValue(pair.Value));
+        }
+
+        builder.Append("---");
+        return builder.ToString();
+    }
+
+    private static string FormatValue(object? value)
+    {
+        if (value is null)
+            return "null";
+        if (value is string text)
+            return FormatString(text);
+        if (value is bool boolean)
+            return boolean ? "true" : "false";
+        if (value is DateTime dateTime)
+            return FormatString(dateTime.ToString("O", CultureInfo.InvariantCulture));
+        if (value is DateTimeOffset dateTimeOffset)
+            return FormatString(dateTimeOffset.ToString("O", CultureInfo.InvariantCulture));
+        if (value is Enum)
+            return FormatString(value.ToString()!);
+        if (value is IEnumerable sequence)
+        {
+            var items = sequence.Cast<object?>().Select(FormatValue);
+            return "[" + string.Join(", ", items) + "]";
+        }
+        if (value is IFormattable formattable)
+            return formattable.ToString(null, CultureInfo.InvariantCulture) ?? "null";
+
+        throw new ArgumentException(
+            $"Unsupported front-matter value type '{value.GetType().FullName}'.");
+    }
+
+    private static string FormatString(string value) =>
+        JsonSerializer.Serialize(value);
+
+    private static string FormatKey(string value) =>
+        Regex.IsMatch(value, @"^[A-Za-z_][A-Za-z0-9_-]*$")
+            ? value
+            : FormatString(value);
+}

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -6,6 +6,8 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xml2Doc.Core;
 using Xml2Doc.Core.Aliasing;
+using Xml2Doc.Core.Anchoring;
+using Xml2Doc.Core.Templates;
 using Xml2Doc.Sample;
 using Xunit;
 
@@ -50,8 +52,19 @@ public class AliasingTests
         };
 
         typeof(RendererOptions).GetConstructor(parameterTypes).ShouldNotBeNull();
+        var aliasProviderSignature =
+            parameterTypes.Concat(new[] { typeof(IAliasProvider) }).ToArray();
+        typeof(RendererOptions).GetConstructor(aliasProviderSignature).ShouldNotBeNull();
+
+        var anchorGeneratorSignature =
+            aliasProviderSignature.Concat(new[] { typeof(IAnchorGenerator) }).ToArray();
+        typeof(RendererOptions).GetConstructor(anchorGeneratorSignature).ShouldNotBeNull();
+
         typeof(RendererOptions)
-            .GetConstructor(parameterTypes.Concat(new[] { typeof(IAliasProvider) }).ToArray())
+            .GetConstructor(
+                anchorGeneratorSignature
+                    .Concat(new[] { typeof(ITemplateRenderer) })
+                    .ToArray())
             .ShouldNotBeNull();
     }
 

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -66,6 +66,19 @@ public class AliasingTests
                     .Concat(new[] { typeof(ITemplateRenderer) })
                     .ToArray())
             .ShouldNotBeNull();
+
+        typeof(RendererOptions)
+            .GetConstructor(
+                anchorGeneratorSignature
+                    .Concat(new[]
+                    {
+                        typeof(ITemplateRenderer),
+                        typeof(Func<
+                            TemplateRenderContext,
+                            IReadOnlyDictionary<string, object?>>)
+                    })
+                    .ToArray())
+            .ShouldNotBeNull();
     }
 
     [Fact]

--- a/Xml2Doc/tests/Xml2Doc.Tests/TemplateRendererTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/TemplateRendererTests.cs
@@ -15,10 +15,10 @@ public class TemplateRendererTests
 
         try
         {
-            var xmlPath = Path.Combine(root, "input.xml");
-            var templatePath = Path.Combine(root, "template.md");
-            var frontMatterPath = Path.Combine(root, "front-matter.yml");
-            var output = Path.Combine(root, "docs");
+            var xmlPath = Path.Join(root, "input.xml");
+            var templatePath = Path.Join(root, "template.md");
+            var frontMatterPath = Path.Join(root, "front-matter.yml");
+            var output = Path.Join(root, "docs");
 
             await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
             await File.WriteAllTextAsync(
@@ -39,12 +39,12 @@ public class TemplateRendererTests
 
             renderer.RenderToDirectory(output);
 
-            var index = await File.ReadAllTextAsync(Path.Combine(output, "index.md"));
+            var index = await File.ReadAllTextAsync(Path.Join(output, "index.md"));
             index.ShouldStartWith("---\nlayout: api\n---\n<!-- index:API Reference -->");
             index.ShouldContain("# API Reference");
             index.ShouldEndWith("<!-- end -->");
 
-            var type = await File.ReadAllTextAsync(Path.Combine(output, "Temp.Widget.md"));
+            var type = await File.ReadAllTextAsync(Path.Join(output, "Temp.Widget.md"));
             type.ShouldStartWith("---\nlayout: api\n---\n<!-- type:Widget -->");
             type.ShouldContain("# Widget");
             type.ShouldEndWith("<!-- end -->");
@@ -62,8 +62,8 @@ public class TemplateRendererTests
 
         try
         {
-            var xmlPath = Path.Combine(root, "input.xml");
-            var output = Path.Combine(root, "api.md");
+            var xmlPath = Path.Join(root, "input.xml");
+            var output = Path.Join(root, "api.md");
             await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
             var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
             var renderer = new MarkdownRenderer(
@@ -102,7 +102,7 @@ public class TemplateRendererTests
 
         try
         {
-            var templatePath = Path.Combine(root, "template.md");
+            var templatePath = Path.Join(root, "template.md");
             await File.WriteAllTextAsync(templatePath, "missing token");
 
             Should.Throw<InvalidDataException>(() =>
@@ -131,10 +131,10 @@ public class TemplateRendererTests
 
     private static string CreateTestRoot()
     {
-        var root = Path.Combine(
+        var root = Path.Join(
             Path.GetTempPath(),
             "Xml2Doc.Tests",
-            Path.GetRandomFileName());
+            Path.GetFileName(Path.GetRandomFileName()));
         Directory.CreateDirectory(root);
         return root;
     }

--- a/Xml2Doc/tests/Xml2Doc.Tests/TemplateRendererTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/TemplateRendererTests.cs
@@ -35,7 +35,8 @@ public class TemplateRendererTests
                 model,
                 new RendererOptions(
                     TemplatePath: templatePath,
-                    FrontMatterPath: frontMatterPath));
+                    FrontMatterPath: frontMatterPath,
+                    EmitNamespaceIndex: true));
 
             renderer.RenderToDirectory(output);
 
@@ -48,6 +49,18 @@ public class TemplateRendererTests
             type.ShouldStartWith("---\nlayout: api\n---\n<!-- type:Widget -->");
             type.ShouldContain("# Widget");
             type.ShouldEndWith("<!-- end -->");
+
+            var namespaceOverview = await File.ReadAllTextAsync(
+                Path.Join(output, "namespaces.md"));
+            namespaceOverview.ShouldStartWith(
+                "---\nlayout: api\n---\n<!-- namespaceoverview:Namespaces -->");
+            namespaceOverview.ShouldContain("# Namespaces");
+
+            var namespaceIndex = await File.ReadAllTextAsync(
+                Path.Join(output, "namespaces", "Temp.md"));
+            namespaceIndex.ShouldStartWith(
+                "---\nlayout: api\n---\n<!-- namespaceindex:Temp -->");
+            namespaceIndex.ShouldContain("# Temp");
         }
         finally
         {
@@ -69,12 +82,25 @@ public class TemplateRendererTests
             var renderer = new MarkdownRenderer(
                 model,
                 new RendererOptions(
-                    TemplateRenderer: new PrefixTemplateRenderer()));
+                    TemplateRenderer: new PrefixTemplateRenderer(),
+                    FrontMatter: context => new Dictionary<string, object?>
+                    {
+                        ["title"] = context.Title,
+                        ["kind"] = context.Kind.ToString().ToLowerInvariant(),
+                        ["draft"] = false
+                    }));
 
             renderer.RenderToSingleFile(output);
 
             var markdown = await File.ReadAllTextAsync(output);
-            markdown.ShouldStartWith("singlefile:API Reference\n# API Reference");
+            markdown.ShouldStartWith(
+                "---\n" +
+                "draft: false\n" +
+                "kind: \"singlefile\"\n" +
+                "title: \"API Reference\"\n" +
+                "---\n" +
+                "singlefile:API Reference\n" +
+                "# API Reference");
         }
         finally
         {
@@ -93,6 +119,19 @@ public class TemplateRendererTests
                 new RendererOptions(
                     TemplatePath: "template.md",
                     TemplateRenderer: new PrefixTemplateRenderer())));
+    }
+
+    [Fact]
+    public void FrontMatterDelegateAndFile_AreRejected()
+    {
+        var model = LoadModel();
+
+        Should.Throw<ArgumentException>(() =>
+            new MarkdownRenderer(
+                model,
+                new RendererOptions(
+                    FrontMatterPath: "front-matter.yml",
+                    FrontMatter: _ => new Dictionary<string, object?>())));
     }
 
     [Fact]

--- a/Xml2Doc/tests/Xml2Doc.Tests/TemplateRendererTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/TemplateRendererTests.cs
@@ -1,0 +1,157 @@
+using Shouldly;
+using System.Text;
+using Xml2Doc.Core;
+using Xml2Doc.Core.Templates;
+using Xunit;
+
+namespace Xml2Doc.Tests;
+
+public class TemplateRendererTests
+{
+    [Fact]
+    public async Task FileTemplateAndFrontMatter_AreAppliedToEveryDirectoryDocument()
+    {
+        var root = CreateTestRoot();
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "input.xml");
+            var templatePath = Path.Combine(root, "template.md");
+            var frontMatterPath = Path.Combine(root, "front-matter.yml");
+            var output = Path.Combine(root, "docs");
+
+            await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
+            await File.WriteAllTextAsync(
+                templatePath,
+                "<!-- {{kind}}:{{title}} -->\n{{content}}\n<!-- end -->",
+                new UTF8Encoding(false));
+            await File.WriteAllTextAsync(
+                frontMatterPath,
+                "---\nlayout: api\n---\n",
+                new UTF8Encoding(false));
+
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+            var renderer = new MarkdownRenderer(
+                model,
+                new RendererOptions(
+                    TemplatePath: templatePath,
+                    FrontMatterPath: frontMatterPath));
+
+            renderer.RenderToDirectory(output);
+
+            var index = await File.ReadAllTextAsync(Path.Combine(output, "index.md"));
+            index.ShouldStartWith("---\nlayout: api\n---\n<!-- index:API Reference -->");
+            index.ShouldContain("# API Reference");
+            index.ShouldEndWith("<!-- end -->");
+
+            var type = await File.ReadAllTextAsync(Path.Combine(output, "Temp.Widget.md"));
+            type.ShouldStartWith("---\nlayout: api\n---\n<!-- type:Widget -->");
+            type.ShouldContain("# Widget");
+            type.ShouldEndWith("<!-- end -->");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CustomTemplateRenderer_IsAppliedToSingleFile()
+    {
+        var root = CreateTestRoot();
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "input.xml");
+            var output = Path.Combine(root, "api.md");
+            await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+            var renderer = new MarkdownRenderer(
+                model,
+                new RendererOptions(
+                    TemplateRenderer: new PrefixTemplateRenderer()));
+
+            renderer.RenderToSingleFile(output);
+
+            var markdown = await File.ReadAllTextAsync(output);
+            markdown.ShouldStartWith("singlefile:API Reference\n# API Reference");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CustomRendererAndFileOptions_AreRejected()
+    {
+        var model = LoadModel();
+
+        Should.Throw<ArgumentException>(() =>
+            new MarkdownRenderer(
+                model,
+                new RendererOptions(
+                    TemplatePath: "template.md",
+                    TemplateRenderer: new PrefixTemplateRenderer())));
+    }
+
+    [Fact]
+    public async Task TemplateWithoutContentToken_IsRejected()
+    {
+        var root = CreateTestRoot();
+
+        try
+        {
+            var templatePath = Path.Combine(root, "template.md");
+            await File.WriteAllTextAsync(templatePath, "missing token");
+
+            Should.Throw<InvalidDataException>(() =>
+                new FileTemplateRenderer(templatePath, frontMatterPath: null));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static Xml2Doc.Core.Models.Xml2Doc LoadModel()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, FixtureXml);
+
+        try
+        {
+            return Xml2Doc.Core.Models.Xml2Doc.Load(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static string CreateTestRoot()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "Xml2Doc.Tests",
+            Path.GetRandomFileName());
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private sealed class PrefixTemplateRenderer : ITemplateRenderer
+    {
+        public string Render(TemplateRenderContext context) =>
+            $"{context.Kind.ToString().ToLowerInvariant()}:{context.Title}\n{context.Content}";
+    }
+
+    private const string FixtureXml = """
+        <doc>
+          <members>
+            <member name="T:Temp.Widget">
+              <summary>A widget.</summary>
+            </member>
+          </members>
+        </doc>
+        """;
+}


### PR DESCRIPTION
## Summary

- introduce public `ITemplateRenderer` and document context types
- preserve existing Markdown through a no-op default renderer
- add file-backed templates with `{{content}}`, `{{title}}`, and `{{kind}}` tokens
- prepend optional front-matter files verbatim
- apply templates consistently to type pages, indexes, namespace indexes, and single-file output
- reject ambiguous combinations of a custom renderer and file-backed options
- preserve all previously published `RendererOptions` constructor signatures
- add end-to-end, custom-renderer, and validation coverage
- document file and programmatic template usage

## Why

The CLI already accepted template and front-matter paths and passed them into Core, but `MarkdownRenderer` ignored those options. Core also lacked the planned programmatic rendering extension point.

## Compatibility

When no template options are supplied, `DefaultTemplateRenderer` returns the built-in Markdown unchanged. Compatibility constructors retain the previously published 19-, 20-, and 21-parameter `RendererOptions` signatures.

## Validation

- `git diff --check`
- existing snapshot coverage continues to protect default output
- new directory, single-file, invalid-template, and configuration-conflict tests added
- GitHub Actions provides authoritative .NET validation because the local workspace has no .NET SDK

Closes #35
Refs #44