### PR TITLE
Add safe opt-in auto linking

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/AutoLinking/AutoLinkContext.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/AutoLinking/AutoLinkContext.cs
@@ -1,0 +1,5 @@
+namespace Xml2Doc.Core.AutoLinking;
+
+/// <summary>Provides the known, mode-specific symbols available for auto-linking.</summary>
+/// <param name="Targets">Unambiguous link targets ordered by label specificity.</param>
+public sealed record AutoLinkContext(IReadOnlyList<AutoLinkTarget> Targets);

--- a/Xml2Doc/src/Xml2Doc.Core/AutoLinking/AutoLinkTarget.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/AutoLinking/AutoLinkTarget.cs
@@ -1,0 +1,6 @@
+namespace Xml2Doc.Core.AutoLinking;
+
+/// <summary>Describes one unambiguous label and its Markdown destination.</summary>
+/// <param name="Label">Visible identifier text to recognize.</param>
+/// <param name="Href">Markdown link destination.</param>
+public sealed record AutoLinkTarget(string Label, string Href);

--- a/Xml2Doc/src/Xml2Doc.Core/AutoLinking/IAutoLinker.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/AutoLinking/IAutoLinker.cs
@@ -1,0 +1,8 @@
+namespace Xml2Doc.Core.AutoLinking;
+
+/// <summary>Links known identifiers in free-form Markdown text.</summary>
+public interface IAutoLinker
+{
+    /// <summary>Applies links while preserving protected Markdown regions.</summary>
+    string Apply(string markdown, AutoLinkContext context);
+}

--- a/Xml2Doc/src/Xml2Doc.Core/AutoLinking/SimpleAutoLinker.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/AutoLinking/SimpleAutoLinker.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Xml2Doc.Core.AutoLinking;
+
+/// <summary>
+/// Links complete identifier tokens while preserving fences, inline code, and existing links.
+/// </summary>
+public sealed class SimpleAutoLinker : IAutoLinker
+{
+    private static readonly Regex ProtectedMarkdown = new(
+        @"(?:`+[^\r\n]*?`+|!?\[[^\]\r\n]*\]\([^\r\n)]*\))",
+        RegexOptions.Compiled);
+
+    /// <summary>The shared stateless instance.</summary>
+    public static SimpleAutoLinker Instance { get; } = new();
+
+    private SimpleAutoLinker()
+    {
+    }
+
+    /// <inheritdoc />
+    public string Apply(string markdown, AutoLinkContext context)
+    {
+        if (markdown is null)
+            throw new ArgumentNullException(nameof(markdown));
+        if (context is null)
+            throw new ArgumentNullException(nameof(context));
+        if (markdown.Length == 0 || context.Targets.Count == 0)
+            return markdown;
+
+        var targets = context.Targets
+            .Where(target =>
+                !string.IsNullOrWhiteSpace(target.Label) &&
+                !string.IsNullOrWhiteSpace(target.Href))
+            .GroupBy(target => target.Label, StringComparer.Ordinal)
+            .Where(group => group.Select(target => target.Href)
+                .Distinct(StringComparer.Ordinal)
+                .Count() == 1)
+            .Select(group => group.First())
+            .OrderByDescending(target => target.Label.Length)
+            .ThenBy(target => target.Label, StringComparer.Ordinal)
+            .ToArray();
+
+        if (targets.Length == 0)
+            return markdown;
+
+        var byLabel = targets.ToDictionary(
+            target => target.Label,
+            StringComparer.Ordinal);
+        var identifierPattern = new Regex(
+            @"(?<![A-Za-z0-9_])(?:" +
+            string.Join("|", targets.Select(target => Regex.Escape(target.Label))) +
+            @")(?![A-Za-z0-9_])");
+        var lines = markdown.Split('\n');
+        var output = new StringBuilder(markdown.Length);
+        char? fenceMarker = null;
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            var trimmed = line.TrimStart();
+            var marker = GetFenceMarker(trimmed);
+
+            if (fenceMarker is null)
+            {
+                if (marker is not null)
+                    fenceMarker = marker;
+                else
+                    line = LinkUnprotected(line, identifierPattern, byLabel);
+            }
+            else if (marker == fenceMarker)
+            {
+                fenceMarker = null;
+            }
+
+            if (index > 0)
+                output.Append('\n');
+            output.Append(line);
+        }
+
+        return output.ToString();
+    }
+
+    private static string LinkUnprotected(
+        string line,
+        Regex identifierPattern,
+        IReadOnlyDictionary<string, AutoLinkTarget> byLabel)
+    {
+        var output = new StringBuilder(line.Length);
+        var position = 0;
+
+        foreach (Match protectedMatch in ProtectedMarkdown.Matches(line))
+        {
+            output.Append(LinkText(
+                line.Substring(position, protectedMatch.Index - position),
+                identifierPattern,
+                byLabel));
+            output.Append(protectedMatch.Value);
+            position = protectedMatch.Index + protectedMatch.Length;
+        }
+
+        output.Append(LinkText(
+            line.Substring(position),
+            identifierPattern,
+            byLabel));
+        return output.ToString();
+    }
+
+    private static string LinkText(
+        string text,
+        Regex identifierPattern,
+        IReadOnlyDictionary<string, AutoLinkTarget> byLabel) =>
+        identifierPattern.Replace(
+            text,
+            match =>
+            {
+                var target = byLabel[match.Value];
+                return $"[{target.Label}]({target.Href})";
+            });
+
+    private static char? GetFenceMarker(string line)
+    {
+        if (line.StartsWith("```", StringComparison.Ordinal))
+            return '`';
+        if (line.StartsWith("~~~", StringComparison.Ordinal))
+            return '~';
+        return null;
+    }
+}

--- a/Xml2Doc/src/Xml2Doc.Core/AutoLinking/SimpleAutoLinker.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/AutoLinking/SimpleAutoLinker.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Runtime.CompilerServices;
 
 namespace Xml2Doc.Core.AutoLinking;
 
@@ -15,6 +16,9 @@ public sealed class SimpleAutoLinker : IAutoLinker
     /// <summary>The shared stateless instance.</summary>
     public static SimpleAutoLinker Instance { get; } = new();
 
+    private readonly ConditionalWeakTable<AutoLinkContext, PreparedTargets>
+        _preparedContexts = new();
+
     private SimpleAutoLinker()
     {
     }
@@ -29,6 +33,15 @@ public sealed class SimpleAutoLinker : IAutoLinker
         if (markdown.Length == 0 || context.Targets.Count == 0)
             return markdown;
 
+        var prepared = _preparedContexts.GetValue(context, PrepareTargets);
+        if (prepared.IdentifierPattern is null)
+            return markdown;
+
+        return ApplyPrepared(markdown, prepared);
+    }
+
+    private static PreparedTargets PrepareTargets(AutoLinkContext context)
+    {
         var targets = context.Targets
             .Where(target =>
                 !string.IsNullOrWhiteSpace(target.Label) &&
@@ -43,7 +56,7 @@ public sealed class SimpleAutoLinker : IAutoLinker
             .ToArray();
 
         if (targets.Length == 0)
-            return markdown;
+            return PreparedTargets.Empty;
 
         var byLabel = targets.ToDictionary(
             target => target.Label,
@@ -52,26 +65,35 @@ public sealed class SimpleAutoLinker : IAutoLinker
             @"(?<![A-Za-z0-9_])(?:" +
             string.Join("|", targets.Select(target => Regex.Escape(target.Label))) +
             @")(?![A-Za-z0-9_])");
+
+        return new PreparedTargets(identifierPattern, byLabel);
+    }
+
+    private static string ApplyPrepared(string markdown, PreparedTargets prepared)
+    {
         var lines = markdown.Split('\n');
         var output = new StringBuilder(markdown.Length);
-        char? fenceMarker = null;
+        Fence? fence = null;
 
         for (var index = 0; index < lines.Length; index++)
         {
             var line = lines[index];
             var trimmed = line.TrimStart();
-            var marker = GetFenceMarker(trimmed);
+            var candidate = GetFence(trimmed);
 
-            if (fenceMarker is null)
+            if (fence is null)
             {
-                if (marker is not null)
-                    fenceMarker = marker;
+                if (candidate is not null)
+                    fence = candidate;
                 else
-                    line = LinkUnprotected(line, identifierPattern, byLabel);
+                    line = LinkUnprotected(
+                        line,
+                        prepared.IdentifierPattern!,
+                        prepared.ByLabel);
             }
-            else if (marker == fenceMarker)
+            else if (IsClosingFence(trimmed, fence.Value))
             {
-                fenceMarker = null;
+                fence = null;
             }
 
             if (index > 0)
@@ -119,12 +141,54 @@ public sealed class SimpleAutoLinker : IAutoLinker
                 return $"[{target.Label}]({target.Href})";
             });
 
-    private static char? GetFenceMarker(string line)
+    private static Fence? GetFence(string line)
     {
-        if (line.StartsWith("```", StringComparison.Ordinal))
-            return '`';
-        if (line.StartsWith("~~~", StringComparison.Ordinal))
-            return '~';
-        return null;
+        if (line.Length < 3 || (line[0] != '`' && line[0] != '~'))
+            return null;
+
+        var marker = line[0];
+        var length = 1;
+        while (length < line.Length && line[length] == marker)
+            length++;
+
+        return length >= 3 ? new Fence(marker, length) : null;
+    }
+
+    private static bool IsClosingFence(string line, Fence opening)
+    {
+        var candidate = GetFence(line);
+        return candidate is not null &&
+               candidate.Value.Marker == opening.Marker &&
+               candidate.Value.Length >= opening.Length &&
+               line.Substring(candidate.Value.Length).Trim().Length == 0;
+    }
+
+    private readonly struct Fence
+    {
+        public Fence(char marker, int length)
+        {
+            Marker = marker;
+            Length = length;
+        }
+
+        public char Marker { get; }
+        public int Length { get; }
+    }
+
+    private sealed class PreparedTargets
+    {
+        public static PreparedTargets Empty { get; } = new(null,
+            new Dictionary<string, AutoLinkTarget>(StringComparer.Ordinal));
+
+        public PreparedTargets(
+            Regex? identifierPattern,
+            IReadOnlyDictionary<string, AutoLinkTarget> byLabel)
+        {
+            IdentifierPattern = identifierPattern;
+            ByLabel = byLabel;
+        }
+
+        public Regex? IdentifierPattern { get; }
+        public IReadOnlyDictionary<string, AutoLinkTarget> ByLabel { get; }
     }
 }

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -11,6 +11,7 @@ using Xml2Doc.Core.OutputLifecycle;
 using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
+using Xml2Doc.Core.AutoLinking;
 
 namespace Xml2Doc.Core;
 
@@ -50,6 +51,9 @@ public sealed class MarkdownRenderer
     private readonly IAliasProvider _aliasProvider;
     private readonly IAnchorGenerator _anchorGenerator;
     private readonly ITemplateRenderer _templateRenderer;
+    private readonly IAutoLinker _autoLinker;
+    private readonly AutoLinkContext _perTypeAutoLinkContext;
+    private readonly AutoLinkContext _singleFileAutoLinkContext;
 
     /// <summary>
     /// Internal link target selection mode for cref resolution (multi‑file vs single‑file).
@@ -95,11 +99,14 @@ public sealed class MarkdownRenderer
                     _opt.TemplatePath,
                     _opt.FrontMatterPath)
                 : DefaultTemplateRenderer.Instance);
+        _autoLinker = _opt.AutoLinker ?? SimpleAutoLinker.Instance;
         _linkResolver = new DefaultLinkResolver(
             labelFromCref: ShortLabelFromCref,
             idToAnchor: IdToAnchor,
             typeFileName: TypeFileNameForResolver,
             headingSlug: HeadingSlug);
+        _perTypeAutoLinkContext = BuildAutoLinkContext(singleFile: false);
+        _singleFileAutoLinkContext = BuildAutoLinkContext(singleFile: true);
     }
 
     // === Public APIs ===
@@ -817,6 +824,31 @@ public sealed class MarkdownRenderer
         sb.Append('[').Append(link.Label).Append("](").Append(link.Href).Append(')');
     }
 
+    private AutoLinkContext BuildAutoLinkContext(bool singleFile)
+    {
+        if (!_opt.AutoLink)
+            return new AutoLinkContext(Array.Empty<AutoLinkTarget>());
+
+        var targets = _model.Members.Values
+            .Where(member => member.Kind is "T" or "M" or "P" or "F" or "E")
+            .Select(member =>
+            {
+                var cref = member.Kind + ":" + member.Id;
+                var link = _linkResolver.Resolve(
+                    cref,
+                    new LinkContext(
+                        CurrentTypeId: null,
+                        SingleFile: singleFile,
+                        BasePath: null));
+                return new AutoLinkTarget(link.Label, link.Href);
+            })
+            .OrderByDescending(target => target.Label.Length)
+            .ThenBy(target => target.Label, StringComparer.Ordinal)
+            .ToArray();
+
+        return new AutoLinkContext(targets);
+    }
+
     /// <summary>
     /// Basic filename builder (mode only; no root namespace trimming).
     /// </summary>
@@ -1105,7 +1137,7 @@ public sealed class MarkdownRenderer
                         }
                     }
                     break;
-                case XElement e when e.Name.LocalName == "paramref":
+                case XElement e when e.Name.LocalName is "paramref" or "typeparamref":
                     var name = (string?)e.Attribute("name") ?? "";
                     text.Append($"`{name}`");
                     break;
@@ -1208,7 +1240,15 @@ public sealed class MarkdownRenderer
             }
         }
 
-        return sbOut.ToString().Trim('\n');
+        var markdown = sbOut.ToString().Trim('\n');
+        if (!_opt.AutoLink)
+            return markdown;
+
+        return _autoLinker.Apply(
+            markdown,
+            _singleFileMode
+                ? _singleFileAutoLinkContext
+                : _perTypeAutoLinkContext);
     }
 
     /// <summary>

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -151,6 +151,17 @@ Keys are ordered ordinally for deterministic output. Supported values include st
 numbers, dates, enums, nulls, and scalar sequences. The delegate cannot be combined with
 `FrontMatterPath`.
 
+Free-text auto-linking is opt-in:
+
+```csharp
+var options = new RendererOptions(AutoLink: true);
+```
+
+The built-in `SimpleAutoLinker` links unambiguous type and member labels using the same
+mode-specific destinations as explicit `cref` links. It does not modify fenced code, inline code,
+existing Markdown links, `paramref`, or `typeparamref` output. To customize the policy, implement
+`IAutoLinker.Apply` and supply `AutoLinker`; the `AutoLink` switch must still be enabled.
+
 ## Tests & Snapshots
 
 - Snapshot tests assert stable Markdown for representative inputs.

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -2,6 +2,7 @@
 using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
+using Xml2Doc.Core.AutoLinking;
 
 namespace Xml2Doc.Core
 {
@@ -146,6 +147,9 @@ namespace Xml2Doc.Core
     /// Optional per-document metadata provider. Returned scalar values are serialized as
     /// deterministic YAML front matter. Cannot be combined with <paramref name="FrontMatterPath"/>.
     /// </param>
+    /// <param name="AutoLinker">
+    /// Optional free-text linker used when <paramref name="AutoLink"/> is true.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -196,9 +200,65 @@ namespace Xml2Doc.Core
         IAliasProvider? AliasProvider = null,
         IAnchorGenerator? AnchorGenerator = null,
         ITemplateRenderer? TemplateRenderer = null,
-        Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter = null
+        Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter = null,
+        IAutoLinker? AutoLinker = null
     )
     {
+        /// <summary>
+        /// Preserves the constructor signature published with front-matter injection.
+        /// </summary>
+        public RendererOptions(
+            FileNameMode FileNameMode,
+            string? RootNamespaceToTrim,
+            string CodeBlockLanguage,
+            bool TrimRootNamespaceInFileNames,
+            AnchorAlgorithm AnchorAlgorithm,
+            string? TemplatePath,
+            string? FrontMatterPath,
+            bool AutoLink,
+            string? AliasMapPath,
+            string? ExternalDocs,
+            bool EmitToc,
+            bool EmitNamespaceIndex,
+            bool BasenameOnly,
+            int? ParallelDegree,
+            bool GenerateIndex,
+            bool PruneStaleFiles,
+            string? ManifestIdentity,
+            LineEndingStyle LineEndings,
+            Action<string>? WarningSink,
+            IAliasProvider? AliasProvider,
+            IAnchorGenerator? AnchorGenerator,
+            ITemplateRenderer? TemplateRenderer,
+            Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter)
+            : this(
+                FileNameMode,
+                RootNamespaceToTrim,
+                CodeBlockLanguage,
+                TrimRootNamespaceInFileNames,
+                AnchorAlgorithm,
+                TemplatePath,
+                FrontMatterPath,
+                AutoLink,
+                AliasMapPath,
+                ExternalDocs,
+                EmitToc,
+                EmitNamespaceIndex,
+                BasenameOnly,
+                ParallelDegree,
+                GenerateIndex,
+                PruneStaleFiles,
+                ManifestIdentity,
+                LineEndings,
+                WarningSink,
+                AliasProvider,
+                AnchorGenerator,
+                TemplateRenderer,
+                FrontMatter,
+                AutoLinker: null)
+        {
+        }
+
         /// <summary>
         /// Preserves the constructor signature published with template-renderer injection.
         /// </summary>
@@ -248,7 +308,8 @@ namespace Xml2Doc.Core
                 AliasProvider,
                 AnchorGenerator,
                 TemplateRenderer,
-                FrontMatter: null)
+                FrontMatter: null,
+                AutoLinker: null)
         {
         }
 
@@ -300,7 +361,8 @@ namespace Xml2Doc.Core
                 AliasProvider,
                 AnchorGenerator,
                 TemplateRenderer: null,
-                FrontMatter: null)
+                FrontMatter: null,
+                AutoLinker: null)
         {
         }
 
@@ -351,7 +413,8 @@ namespace Xml2Doc.Core
                 AliasProvider,
                 AnchorGenerator: null,
                 TemplateRenderer: null,
-                FrontMatter: null)
+                FrontMatter: null,
+                AutoLinker: null)
         {
         }
 
@@ -401,7 +464,8 @@ namespace Xml2Doc.Core
                 AliasProvider: null,
                 AnchorGenerator: null,
                 TemplateRenderer: null,
-                FrontMatter: null)
+                FrontMatter: null,
+                AutoLinker: null)
         {
         }
     }

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -8,6 +8,7 @@ using Xml2Doc.Core;
 using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
+using Xml2Doc.Core.AutoLinking;
 using Xml2Doc.Sample;
 using Xunit;
 
@@ -64,6 +65,20 @@ public class AliasingTests
             .GetConstructor(
                 anchorGeneratorSignature
                     .Concat(new[] { typeof(ITemplateRenderer) })
+                    .ToArray())
+            .ShouldNotBeNull();
+
+        typeof(RendererOptions)
+            .GetConstructor(
+                anchorGeneratorSignature
+                    .Concat(new[]
+                    {
+                        typeof(ITemplateRenderer),
+                        typeof(Func<
+                            TemplateRenderContext,
+                            IReadOnlyDictionary<string, object?>>),
+                        typeof(IAutoLinker)
+                    })
                     .ToArray())
             .ShouldNotBeNull();
 

--- a/Xml2Doc/tests/Xml2Doc.Tests/AutoLinkerTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AutoLinkerTests.cs
@@ -1,0 +1,161 @@
+using Shouldly;
+using System.Text;
+using Xml2Doc.Core;
+using Xml2Doc.Core.AutoLinking;
+using Xunit;
+
+namespace Xml2Doc.Tests;
+
+public class AutoLinkerTests
+{
+    [Fact]
+    public void SimpleAutoLinker_SkipsProtectedMarkdownAndPartialIdentifiers()
+    {
+        var markdown = """
+            Widget calls Run(string).
+            `Widget` and [Widget](existing.md) and WidgetFactory
+            ```csharp
+            Widget calls Run(string).
+            ```
+            ~~~text
+            Widget
+            ~~~
+            """;
+        var context = new AutoLinkContext(new[]
+        {
+            new AutoLinkTarget("Widget", "Widget.md"),
+            new AutoLinkTarget("Run(string)", "Widget.md#run")
+        });
+
+        var result = SimpleAutoLinker.Instance.Apply(markdown, context);
+
+        result.ShouldContain("[Widget](Widget.md) calls [Run(string)](Widget.md#run).");
+        result.ShouldContain("`Widget` and [Widget](existing.md) and WidgetFactory");
+        result.ShouldContain("```csharp\nWidget calls Run(string).\n```");
+        result.ShouldContain("~~~text\nWidget\n~~~");
+    }
+
+    [Fact]
+    public async Task Renderer_AutoLinksWithModeSpecificTargets()
+    {
+        var root = CreateTestRoot();
+
+        try
+        {
+            var xmlPath = Path.Join(root, "input.xml");
+            await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+
+            var directory = Path.Join(root, "docs");
+            new MarkdownRenderer(model, new RendererOptions(AutoLink: true))
+                .RenderToDirectory(directory);
+            var perType = await File.ReadAllTextAsync(
+                Path.Join(directory, "Temp.Consumer.md"));
+
+            perType.ShouldContain("[Widget](Temp.Widget.md)");
+            perType.ShouldContain(
+                "[Run(string)](Temp.Widget.md#temp.widget.run(string))");
+            perType.ShouldContain("`Widget`");
+            perType.ShouldContain("`T`");
+
+            var singleFile = Path.Join(root, "api.md");
+            new MarkdownRenderer(model, new RendererOptions(AutoLink: true))
+                .RenderToSingleFile(singleFile);
+            var single = await File.ReadAllTextAsync(singleFile);
+
+            single.ShouldContain("[Widget](#widget)");
+            single.ShouldContain("[Run(string)](#temp.widget.run(string))");
+            single.ShouldContain("`Widget`");
+            single.ShouldContain("`T`");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Renderer_LeavesFreeTextUnchangedByDefault()
+    {
+        var root = CreateTestRoot();
+
+        try
+        {
+            var xmlPath = Path.Join(root, "input.xml");
+            await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+            var output = Path.Join(root, "docs");
+
+            new MarkdownRenderer(model).RenderToDirectory(output);
+            var markdown = await File.ReadAllTextAsync(
+                Path.Join(output, "Temp.Consumer.md"));
+
+            markdown.ShouldContain("Widget calls Run(string).");
+            markdown.ShouldNotContain("[Widget](Temp.Widget.md)");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Renderer_UsesCustomAutoLinkerWhenEnabled()
+    {
+        var model = LoadModel();
+        var renderer = new MarkdownRenderer(
+            model,
+            new RendererOptions(
+                AutoLink: true,
+                AutoLinker: new PrefixAutoLinker()));
+
+        renderer.RenderToString().ShouldContain("linked:Widget calls Run(string).");
+    }
+
+    private static Xml2Doc.Core.Models.Xml2Doc LoadModel()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, FixtureXml);
+
+        try
+        {
+            return Xml2Doc.Core.Models.Xml2Doc.Load(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static string CreateTestRoot()
+    {
+        var root = Path.Join(
+            Path.GetTempPath(),
+            "Xml2Doc.Tests",
+            Path.GetFileName(Path.GetRandomFileName()));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private sealed class PrefixAutoLinker : IAutoLinker
+    {
+        public string Apply(string markdown, AutoLinkContext context) =>
+            "linked:" + markdown;
+    }
+
+    private const string FixtureXml = """
+        <doc>
+          <members>
+            <member name="T:Temp.Widget">
+              <summary>A widget.</summary>
+            </member>
+            <member name="M:Temp.Widget.Run(System.String)">
+              <summary>Runs a widget.</summary>
+            </member>
+            <member name="T:Temp.Consumer">
+              <summary>Widget calls Run(string). Use <c>Widget</c> with <typeparamref name="T"/>.</summary>
+            </member>
+          </members>
+        </doc>
+        """;
+}

--- a/Xml2Doc/tests/Xml2Doc.Tests/AutoLinkerTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AutoLinkerTests.cs
@@ -27,7 +27,9 @@ public class AutoLinkerTests
             new AutoLinkTarget("Run(string)", "Widget.md#run")
         });
 
-        var result = SimpleAutoLinker.Instance.Apply(markdown, context);
+        var result = SimpleAutoLinker.Instance
+            .Apply(markdown, context)
+            .ReplaceLineEndings("\n");
 
         result.ShouldContain("[Widget](Widget.md) calls [Run(string)](Widget.md#run).");
         result.ShouldContain("`Widget` and [Widget](existing.md) and WidgetFactory");

--- a/Xml2Doc/tests/Xml2Doc.Tests/AutoLinkerTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AutoLinkerTests.cs
@@ -38,6 +38,43 @@ public class AutoLinkerTests
     }
 
     [Fact]
+    public void SimpleAutoLinker_DoesNotCloseLongFenceWithShorterFence()
+    {
+        var markdown = """
+            ````csharp
+            Widget
+            ```
+            Widget
+            ````
+            Widget
+            """;
+        var context = new AutoLinkContext(new[]
+        {
+            new AutoLinkTarget("Widget", "Widget.md")
+        });
+
+        var result = SimpleAutoLinker.Instance
+            .Apply(markdown, context)
+            .ReplaceLineEndings("\n");
+
+        result.ShouldBe(
+            "````csharp\nWidget\n```\nWidget\n````\n[Widget](Widget.md)");
+    }
+
+    [Fact]
+    public void SimpleAutoLinker_PreparesTargetsOncePerContext()
+    {
+        var targets = new TrackingTargets(
+            new AutoLinkTarget("Widget", "Widget.md"));
+        var context = new AutoLinkContext(targets);
+
+        SimpleAutoLinker.Instance.Apply("Widget", context);
+        SimpleAutoLinker.Instance.Apply("Widget again", context);
+
+        targets.EnumerationCount.ShouldBe(1);
+    }
+
+    [Fact]
     public async Task Renderer_AutoLinksWithModeSpecificTargets()
     {
         var root = CreateTestRoot();
@@ -143,6 +180,27 @@ public class AutoLinkerTests
     {
         public string Apply(string markdown, AutoLinkContext context) =>
             "linked:" + markdown;
+    }
+
+    private sealed class TrackingTargets : IReadOnlyList<AutoLinkTarget>
+    {
+        private readonly AutoLinkTarget[] _targets;
+
+        public TrackingTargets(params AutoLinkTarget[] targets) =>
+            _targets = targets;
+
+        public int EnumerationCount { get; private set; }
+        public int Count => _targets.Length;
+        public AutoLinkTarget this[int index] => _targets[index];
+
+        public IEnumerator<AutoLinkTarget> GetEnumerator()
+        {
+            EnumerationCount++;
+            return ((IEnumerable<AutoLinkTarget>)_targets).GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
     }
 
     private const string FixtureXml = """


### PR DESCRIPTION
## Summary

- introduce public `IAutoLinker`, `AutoLinkContext`, and `AutoLinkTarget`
- add opt-in `SimpleAutoLinker` using existing mode-specific link resolution
- skip fenced code, inline code, and existing Markdown links
- avoid partial identifiers and ambiguous labels
- preserve `paramref` and `typeparamref` output as protected inline code
- support custom auto-linker injection through `RendererOptions`
- preserve previously published `RendererOptions` constructor signatures
- add default-off, routing, custom-provider, and safety coverage
- document the extension point

## Why

`RendererOptions.AutoLink` and CLI/config wiring existed, but Core did not apply free-text linking or expose the planned service.

## Compatibility

Auto-linking remains off by default. When enabled without a custom provider, `SimpleAutoLinker` uses existing resolver destinations. Existing output remains unchanged when disabled.

## Validation

- `git diff --check`
- new per-type and single-file routing tests
- protected Markdown and partial-identifier safety tests
- GitHub Actions is the authoritative .NET validation because this workspace has no .NET SDK

Closes #36
Refs #43
Refs #44