### PR TITLE
Add external cref fallback

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/Linking/BaseUrlExternalSymbolResolver.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Linking/BaseUrlExternalSymbolResolver.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Xml2Doc.Core.Linking;
+
+/// <summary>
+/// Resolves symbols beneath a common documentation URL by appending the escaped
+/// identifier without its XML documentation kind prefix.
+/// </summary>
+public sealed class BaseUrlExternalSymbolResolver : IExternalSymbolResolver
+{
+    private readonly string _baseUrl;
+
+    /// <summary>Creates a resolver for the supplied documentation base URL.</summary>
+    /// <param name="baseUrl">The non-empty URL prefix used for resolved symbols.</param>
+    public BaseUrlExternalSymbolResolver(string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            throw new ArgumentException("A documentation base URL is required.", nameof(baseUrl));
+
+        _baseUrl = baseUrl.Trim().TrimEnd('/');
+    }
+
+    /// <inheritdoc />
+    public bool TryResolve(string cref, out string? href)
+    {
+        if (string.IsNullOrWhiteSpace(cref))
+        {
+            href = null;
+            return false;
+        }
+
+        var identifier = cref.Length > 1 && cref[1] == ':'
+            ? cref.Substring(2)
+            : cref;
+        href = _baseUrl + "/" + Uri.EscapeDataString(identifier);
+        return true;
+    }
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Linking/DefaultLinkResolver.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Linking/DefaultLinkResolver.cs
@@ -12,17 +12,26 @@ namespace Xml2Doc.Core.Linking
         private readonly Func<string, string> _idToAnchor;
         private readonly Func<string, string> _typeFileName;
         private readonly Func<string, string> _headingSlug;
+        private readonly Func<string, bool> _isKnownCref;
+        private readonly LinkPolicy _linkPolicy;
+        private readonly IExternalSymbolResolver? _externalSymbolResolver;
 
         internal DefaultLinkResolver(
             Func<string, string> labelFromCref,
             Func<string, string> idToAnchor,
             Func<string, string> typeFileName,
-            Func<string, string> headingSlug)
+            Func<string, string> headingSlug,
+            Func<string, bool> isKnownCref,
+            LinkPolicy linkPolicy,
+            IExternalSymbolResolver? externalSymbolResolver)
         {
             _labelFromCref = labelFromCref ?? throw new ArgumentNullException(nameof(labelFromCref));
             _idToAnchor = idToAnchor ?? throw new ArgumentNullException(nameof(idToAnchor));
             _typeFileName = typeFileName ?? throw new ArgumentNullException(nameof(typeFileName));
             _headingSlug = headingSlug ?? throw new ArgumentNullException(nameof(headingSlug));
+            _isKnownCref = isKnownCref ?? throw new ArgumentNullException(nameof(isKnownCref));
+            _linkPolicy = linkPolicy;
+            _externalSymbolResolver = externalSymbolResolver;
         }
 
         public MarkdownLink Resolve(string cref, LinkContext ctx)
@@ -31,6 +40,15 @@ namespace Xml2Doc.Core.Linking
             var isCref = !string.IsNullOrWhiteSpace(cref) && cref.Length > 1 && cref[1] == ':';
             var kind = isCref ? cref[0] : '?';
             var label = _labelFromCref(cref);
+
+            if (_linkPolicy == LinkPolicy.PreferExternalForUnknown &&
+                !_isKnownCref(cref) &&
+                _externalSymbolResolver is not null &&
+                _externalSymbolResolver.TryResolve(cref, out var externalHref) &&
+                !string.IsNullOrWhiteSpace(externalHref))
+            {
+                return new MarkdownLink(externalHref!, label);
+            }
 
             // Derive the id portion (strip the leading "X:" if present) so anchors do not contain the kind prefix.
             // Many callers (e.g., renderer emission) call IdToAnchor with the plain id (no "M:"/"T:"), so the resolver

--- a/Xml2Doc/src/Xml2Doc.Core/Linking/IExternalSymbolResolver.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Linking/IExternalSymbolResolver.cs
@@ -1,0 +1,14 @@
+namespace Xml2Doc.Core.Linking;
+
+/// <summary>Resolves XML documentation identifiers to external documentation URLs.</summary>
+public interface IExternalSymbolResolver
+{
+    /// <summary>
+    /// Attempts to resolve an XML documentation identifier such as
+    /// <c>T:System.String</c> to an absolute or site-relative URL.
+    /// </summary>
+    /// <param name="cref">The complete XML documentation identifier.</param>
+    /// <param name="href">The resolved URL when successful.</param>
+    /// <returns><see langword="true"/> when a non-empty URL was resolved.</returns>
+    bool TryResolve(string cref, out string? href);
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Linking/LinkPolicy.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Linking/LinkPolicy.cs
@@ -1,0 +1,14 @@
+namespace Xml2Doc.Core.Linking;
+
+/// <summary>Controls how unresolved XML documentation links are routed.</summary>
+public enum LinkPolicy
+{
+    /// <summary>Preserve the existing internal-link behavior for every cref.</summary>
+    InternalOnly,
+
+    /// <summary>
+    /// Prefer a configured external resolver when the cref is not part of the
+    /// rendered documentation model.
+    /// </summary>
+    PreferExternalForUnknown
+}

--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -100,11 +100,18 @@ public sealed class MarkdownRenderer
                     _opt.FrontMatterPath)
                 : DefaultTemplateRenderer.Instance);
         _autoLinker = _opt.AutoLinker ?? SimpleAutoLinker.Instance;
+        var externalSymbolResolver = _opt.ExternalSymbolResolver ??
+            (!string.IsNullOrWhiteSpace(_opt.ExternalDocs)
+                ? new BaseUrlExternalSymbolResolver(_opt.ExternalDocs!)
+                : null);
         _linkResolver = new DefaultLinkResolver(
             labelFromCref: ShortLabelFromCref,
             idToAnchor: IdToAnchor,
             typeFileName: TypeFileNameForResolver,
-            headingSlug: HeadingSlug);
+            headingSlug: HeadingSlug,
+            isKnownCref: cref => _model.Members.ContainsKey(cref),
+            linkPolicy: _opt.LinkPolicy,
+            externalSymbolResolver: externalSymbolResolver);
         _perTypeAutoLinkContext = BuildAutoLinkContext(singleFile: false);
         _singleFileAutoLinkContext = BuildAutoLinkContext(singleFile: true);
     }

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -162,6 +162,21 @@ mode-specific destinations as explicit `cref` links. It does not modify fenced c
 existing Markdown links, `paramref`, or `typeparamref` output. To customize the policy, implement
 `IAutoLinker.Apply` and supply `AutoLinker`; the `AutoLink` switch must still be enabled.
 
+External cref fallback is also opt-in:
+
+```csharp
+var options = new RendererOptions(
+    LinkPolicy: LinkPolicy.PreferExternalForUnknown,
+    ExternalDocs: "https://learn.microsoft.com/dotnet/api");
+```
+
+Crefs present in the rendered model always retain their normal per-type or single-file links.
+Only unknown crefs are offered to the external provider. `ExternalDocs` uses
+`BaseUrlExternalSymbolResolver`, which appends the escaped documentation identifier without its
+kind prefix. For other routing rules, implement `IExternalSymbolResolver` and pass it as
+`ExternalSymbolResolver`. If the provider declines a symbol, Xml2Doc preserves its existing
+internal-link fallback.
+
 ## Tests & Snapshots
 
 - Snapshot tests assert stable Markdown for representative inputs.

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -3,6 +3,7 @@ using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
 using Xml2Doc.Core.AutoLinking;
+using Xml2Doc.Core.Linking;
 
 namespace Xml2Doc.Core
 {
@@ -99,7 +100,8 @@ namespace Xml2Doc.Core
     /// Path to a JSON/text alias map adding custom type/namespace replacements beyond built‑in C# keyword aliases.
     /// </param>
     /// <param name="ExternalDocs">
-    /// Base URL (or map) for external documentation used for unresolved cref targets (e.g. framework APIs).
+    /// Base URL for external documentation used for unresolved cref targets (e.g. framework APIs).
+    /// Requires <see cref="LinkPolicy.PreferExternalForUnknown"/>.
     /// </param>
     /// <param name="EmitToc">
     /// When true, emits a member table of contents per type in multi‑file mode (suppressed in single‑file mode).
@@ -149,6 +151,15 @@ namespace Xml2Doc.Core
     /// </param>
     /// <param name="AutoLinker">
     /// Optional free-text linker used when <paramref name="AutoLink"/> is true.
+    /// </param>
+    /// <param name="LinkPolicy">
+    /// Controls whether unresolved cref targets retain the existing internal-link
+    /// behavior or are offered to an external resolver.
+    /// </param>
+    /// <param name="ExternalSymbolResolver">
+    /// Optional provider for unresolved cref targets. When omitted and
+    /// <paramref name="ExternalDocs"/> is set, a
+    /// <see cref="BaseUrlExternalSymbolResolver"/> is used.
     /// </param>
     /// <remarks>
     /// Example:
@@ -201,9 +212,69 @@ namespace Xml2Doc.Core
         IAnchorGenerator? AnchorGenerator = null,
         ITemplateRenderer? TemplateRenderer = null,
         Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter = null,
-        IAutoLinker? AutoLinker = null
+        IAutoLinker? AutoLinker = null,
+        LinkPolicy LinkPolicy = LinkPolicy.InternalOnly,
+        IExternalSymbolResolver? ExternalSymbolResolver = null
     )
     {
+        /// <summary>
+        /// Preserves the constructor signature published with auto-linker injection.
+        /// </summary>
+        public RendererOptions(
+            FileNameMode FileNameMode,
+            string? RootNamespaceToTrim,
+            string CodeBlockLanguage,
+            bool TrimRootNamespaceInFileNames,
+            AnchorAlgorithm AnchorAlgorithm,
+            string? TemplatePath,
+            string? FrontMatterPath,
+            bool AutoLink,
+            string? AliasMapPath,
+            string? ExternalDocs,
+            bool EmitToc,
+            bool EmitNamespaceIndex,
+            bool BasenameOnly,
+            int? ParallelDegree,
+            bool GenerateIndex,
+            bool PruneStaleFiles,
+            string? ManifestIdentity,
+            LineEndingStyle LineEndings,
+            Action<string>? WarningSink,
+            IAliasProvider? AliasProvider,
+            IAnchorGenerator? AnchorGenerator,
+            ITemplateRenderer? TemplateRenderer,
+            Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter,
+            IAutoLinker? AutoLinker)
+            : this(
+                FileNameMode,
+                RootNamespaceToTrim,
+                CodeBlockLanguage,
+                TrimRootNamespaceInFileNames,
+                AnchorAlgorithm,
+                TemplatePath,
+                FrontMatterPath,
+                AutoLink,
+                AliasMapPath,
+                ExternalDocs,
+                EmitToc,
+                EmitNamespaceIndex,
+                BasenameOnly,
+                ParallelDegree,
+                GenerateIndex,
+                PruneStaleFiles,
+                ManifestIdentity,
+                LineEndings,
+                WarningSink,
+                AliasProvider,
+                AnchorGenerator,
+                TemplateRenderer,
+                FrontMatter,
+                AutoLinker,
+                LinkPolicy: LinkPolicy.InternalOnly,
+                ExternalSymbolResolver: null)
+        {
+        }
+
         /// <summary>
         /// Preserves the constructor signature published with front-matter injection.
         /// </summary>

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -9,6 +9,7 @@ using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
 using Xml2Doc.Core.AutoLinking;
+using Xml2Doc.Core.Linking;
 using Xml2Doc.Sample;
 using Xunit;
 
@@ -65,6 +66,22 @@ public class AliasingTests
             .GetConstructor(
                 anchorGeneratorSignature
                     .Concat(new[] { typeof(ITemplateRenderer) })
+                    .ToArray())
+            .ShouldNotBeNull();
+
+        typeof(RendererOptions)
+            .GetConstructor(
+                anchorGeneratorSignature
+                    .Concat(new[]
+                    {
+                        typeof(ITemplateRenderer),
+                        typeof(Func<
+                            TemplateRenderContext,
+                            IReadOnlyDictionary<string, object?>>),
+                        typeof(IAutoLinker),
+                        typeof(LinkPolicy),
+                        typeof(IExternalSymbolResolver)
+                    })
                     .ToArray())
             .ShouldNotBeNull();
 

--- a/Xml2Doc/tests/Xml2Doc.Tests/ExternalLinkingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/ExternalLinkingTests.cs
@@ -1,0 +1,118 @@
+using Shouldly;
+using System.Text;
+using Xml2Doc.Core;
+using Xml2Doc.Core.Linking;
+using Xunit;
+
+namespace Xml2Doc.Tests;
+
+public class ExternalLinkingTests
+{
+    [Fact]
+    public async Task PreferExternalForUnknown_UsesExternalOnlyForUnknownCrefs()
+    {
+        var resolver = new RecordingExternalResolver();
+        var markdown = await RenderAsync(new RendererOptions(
+            LinkPolicy: LinkPolicy.PreferExternalForUnknown,
+            ExternalSymbolResolver: resolver));
+
+        markdown.ShouldContain("[Widget](Temp.Widget.md)");
+        markdown.ShouldContain("[String](https://docs.example/System.String)");
+        resolver.Requests.ShouldBe(new[] { "T:System.String" });
+    }
+
+    [Fact]
+    public async Task InternalOnly_PreservesExistingBehaviorAndSkipsProvider()
+    {
+        var resolver = new RecordingExternalResolver();
+        var markdown = await RenderAsync(new RendererOptions(
+            ExternalSymbolResolver: resolver));
+
+        markdown.ShouldContain("[Widget](Temp.Widget.md)");
+        markdown.ShouldContain("[String](System.String.md)");
+        resolver.Requests.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PreferExternalForUnknown_FallsBackWhenProviderDeclines()
+    {
+        var markdown = await RenderAsync(new RendererOptions(
+            LinkPolicy: LinkPolicy.PreferExternalForUnknown,
+            ExternalSymbolResolver: new DecliningExternalResolver()));
+
+        markdown.ShouldContain("[String](System.String.md)");
+    }
+
+    [Fact]
+    public void BaseUrlResolver_AppendsEscapedIdentifierWithoutKindPrefix()
+    {
+        var resolver = new BaseUrlExternalSymbolResolver(
+            "https://learn.microsoft.com/dotnet/api/");
+
+        resolver.TryResolve("T:System.String", out var href).ShouldBeTrue();
+        href.ShouldBe("https://learn.microsoft.com/dotnet/api/System.String");
+    }
+
+    private static async Task<string> RenderAsync(RendererOptions options)
+    {
+        var root = Path.Join(
+            Path.GetTempPath(),
+            "Xml2Doc.Tests",
+            Path.GetFileName(Path.GetRandomFileName()));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Join(root, "input.xml");
+            await File.WriteAllTextAsync(xmlPath, FixtureXml, new UTF8Encoding(false));
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(xmlPath);
+            var output = Path.Join(root, "docs");
+
+            new MarkdownRenderer(model, options).RenderToDirectory(output);
+            return await File.ReadAllTextAsync(
+                Path.Join(output, "Temp.Consumer.md"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class RecordingExternalResolver : IExternalSymbolResolver
+    {
+        public List<string> Requests { get; } = new();
+
+        public bool TryResolve(string cref, out string? href)
+        {
+            Requests.Add(cref);
+            href = cref == "T:System.String"
+                ? "https://docs.example/System.String"
+                : null;
+            return href is not null;
+        }
+    }
+
+    private sealed class DecliningExternalResolver : IExternalSymbolResolver
+    {
+        public bool TryResolve(string cref, out string? href)
+        {
+            href = null;
+            return false;
+        }
+    }
+
+    private const string FixtureXml = """
+        <doc>
+          <members>
+            <member name="T:Temp.Consumer">
+              <summary>
+                See <see cref="T:Temp.Widget"/> and <see cref="T:System.String"/>.
+              </summary>
+            </member>
+            <member name="T:Temp.Widget">
+              <summary>A local widget.</summary>
+            </member>
+          </members>
+        </doc>
+        """;
+}


### PR DESCRIPTION
## Summary

- introduce public `IExternalSymbolResolver` and `LinkPolicy`
- add `LinkPolicy.PreferExternalForUnknown` as an explicit opt-in
- add `BaseUrlExternalSymbolResolver` for the existing `ExternalDocs` option
- keep known symbols on their existing per-type or single-file destinations
- preserve current internal-link behavior when external resolution is disabled or declined
- support custom external routing through `RendererOptions.ExternalSymbolResolver`
- preserve previously published `RendererOptions` constructor signatures
- add provider, policy, fallback, and compatibility tests
- document external cref configuration

## Why

Xml2Doc exposed an `ExternalDocs` placeholder but did not use it, and unresolved crefs were always routed through the internal link resolver. Consumers could not redirect framework or third-party symbols to external documentation.

## Compatibility

External fallback is off by default. Existing output remains unchanged unless `LinkPolicy.PreferExternalForUnknown` is selected. Crefs present in the rendered model always retain their existing internal destinations.

## Validation

- `git diff --check`
- tests cover known versus unknown symbols
- tests cover disabled and declining providers
- tests cover the base-URL resolver
- constructor compatibility coverage updated
- GitHub Actions is the authoritative .NET validation because this workspace has no .NET SDK

Closes #38
Refs #44