### PR TITLE
Extract signature rendering service

### DIFF
--- a/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/MarkdownRenderer.cs
@@ -12,6 +12,7 @@ using Xml2Doc.Core.Aliasing;
 using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
 using Xml2Doc.Core.AutoLinking;
+using Xml2Doc.Core.Signatures;
 
 namespace Xml2Doc.Core;
 
@@ -52,6 +53,8 @@ public sealed class MarkdownRenderer
     private readonly IAnchorGenerator _anchorGenerator;
     private readonly ITemplateRenderer _templateRenderer;
     private readonly IAutoLinker _autoLinker;
+    private readonly ISignatureRenderer _signatureRenderer;
+    private readonly SignatureStyle _signatureStyle;
     private readonly AutoLinkContext _perTypeAutoLinkContext;
     private readonly AutoLinkContext _singleFileAutoLinkContext;
 
@@ -74,6 +77,11 @@ public sealed class MarkdownRenderer
         _model = model;
         _opt = options ?? new RendererOptions();
         _aliasProvider = _opt.AliasProvider ?? DefaultAliasProvider.Instance;
+        _signatureStyle = _opt.SignatureStyle ?? SignatureStyle.Default;
+        _signatureRenderer = _opt.SignatureRenderer ??
+            new DefaultSignatureRenderer(
+                _aliasProvider,
+                _opt.RootNamespaceToTrim);
         _anchorGenerator = _opt.AnchorGenerator ??
             new DefaultAnchorGenerator(_opt.AnchorAlgorithm, _aliasProvider);
         if (_opt.TemplateRenderer is not null &&
@@ -105,7 +113,7 @@ public sealed class MarkdownRenderer
                 ? new BaseUrlExternalSymbolResolver(_opt.ExternalDocs!)
                 : null);
         _linkResolver = new DefaultLinkResolver(
-            labelFromCref: ShortLabelFromCref,
+            labelFromCref: _signatureRenderer.RenderCrefLabel,
             idToAnchor: IdToAnchor,
             typeFileName: TypeFileNameForResolver,
             headingSlug: HeadingSlug,
@@ -167,7 +175,7 @@ public sealed class MarkdownRenderer
                     file,
                     NormalizeLineEndings(ApplyTemplate(
                         RenderType(t, includeHeader: true),
-                        ShortTypeDisplay(t.Id),
+                        _signatureRenderer.RenderTypeName(t.Id),
                         TemplateDocumentKind.Type)),
                     MarkdownEncoding);
             }
@@ -204,7 +212,7 @@ public sealed class MarkdownRenderer
                     sbNs.AppendLine($"# {ns}");
                     foreach (var t in kv.Value.OrderBy(t => t.Id, StringComparer.Ordinal))
                     {
-                        var shortName = ShortTypeDisplay(t.Id);
+                        var shortName = _signatureRenderer.RenderTypeName(t.Id);
                         var perTypeFile = FileNameForPerType(t.Id);
                         sbNs.AppendLine($"- [{shortName}]({Path.Combine("..", perTypeFile).Replace('\\', '/')})");
                     }
@@ -334,7 +342,7 @@ public sealed class MarkdownRenderer
             for (int i = 0; i < types.Count; i++)
             {
                 var t = types[i];
-                var typeDisplay = ShortTypeDisplay(t.Id);
+                var typeDisplay = _signatureRenderer.RenderTypeName(t.Id);
                 sb.AppendLine($"<a id=\"{HeadingSlug(typeDisplay)}\"></a>");
                 sb.AppendLine($"# {typeDisplay}");
                 sb.AppendLine();
@@ -392,7 +400,7 @@ public sealed class MarkdownRenderer
         sb.AppendLine("# API Reference");
         foreach (var t in types)
         {
-            var shortName = ShortTypeDisplay(t.Id);
+            var shortName = _signatureRenderer.RenderTypeName(t.Id);
             var link = useAnchors ? $"#{HeadingSlug(shortName)}" : FileNameForPerType(t.Id);
             sb.AppendLine($"- [{shortName}]({link})");
         }
@@ -407,7 +415,7 @@ public sealed class MarkdownRenderer
     private string RenderType(XMember type, bool includeHeader = true)
     {
         var sb = new StringBuilder();
-        var typeDisplay = ShortTypeDisplay(type.Id);
+        var typeDisplay = _signatureRenderer.RenderTypeName(type.Id);
 
         if (includeHeader)
         {
@@ -609,172 +617,6 @@ public sealed class MarkdownRenderer
         _anchorGenerator.GenerateHeadingAnchor(heading);
 
     /// <summary>
-    /// Builds a concise member header (Kind + simplified signature) for headings and overload bullets.
-    /// </summary>
-    private string MemberHeader(XMember m)
-    {
-        var id = m.Id;
-        var parenIdx = id.IndexOf('(');
-        var cut = parenIdx >= 0 ? id.LastIndexOf('.', parenIdx) : id.LastIndexOf('.');
-        var namePart = cut >= 0 ? id.Substring(cut + 1) : id;
-
-        namePart = Regex.Replace(namePart, @"\((.*)\)", match =>
-        {
-            var inner = match.Groups[1].Value;
-            if (string.IsNullOrWhiteSpace(inner)) return "()";
-
-            static IEnumerable<string> SplitParams(string s)
-            {
-                var depth = 0; var start = 0;
-                for (int i = 0; i < s.Length; i++)
-                {
-                    var ch = s[i];
-                    if (ch == '{') depth++;
-                    else if (ch == '}') depth--;
-                    else if (ch == ',' && depth == 0)
-                    {
-                        yield return s.Substring(start, i - start);
-                        start = i + 1;
-                    }
-                }
-                yield return s.Substring(start);
-            }
-
-            var parts = SplitParams(inner).Select(p => p.Trim());
-            var simplified = parts.Select(ShortenSignatureType).ToArray();
-            return $"({string.Join(", ", simplified)})";
-        });
-
-        namePart = Regex.Replace(namePart, @"``(\d+)", m2 =>
-        {
-            var n = int.Parse(m2.Groups[1].Value);
-            return $"<{string.Join(",", Enumerable.Range(1, n).Select(i => $"T{i}"))}>";
-        });
-
-        return $"{KindToWord(m.Kind)}: {namePart}";
-    }
-
-    /// <summary>
-    /// Maps XML documentation kind letter to a readable word.
-    /// </summary>
-    private static string KindToWord(string kind) => kind switch
-    {
-        "M" => "Method",
-        "P" => "Property",
-        "F" => "Field",
-        "E" => "Event",
-        "T" => "Type",
-        _ => kind
-    };
-
-    /// <summary>
-    /// Produces a short display name for a type ID (generic arity → &lt;T…&gt;, optional root namespace trimming).
-    /// </summary>
-    private string ShortTypeDisplay(string typeId)
-    {
-        if (typeId.IndexOf('{') >= 0 || typeId.IndexOf('}') >= 0 || typeId.IndexOf('<') >= 0)
-        {
-            var normalized = typeId.Replace('{', '<').Replace('}', '>');
-            var display = ShortenSignatureType(normalized);
-
-            if (_opt.RootNamespaceToTrim is string root && root.Length > 0 &&
-                display.StartsWith(root + ".", StringComparison.Ordinal))
-            {
-                display = display.Substring(root.Length + 1);
-            }
-            return display;
-        }
-
-        var id = typeId;
-        if (_opt.RootNamespaceToTrim is string root2 && root2.Length > 0 &&
-            id.StartsWith(root2 + ".", StringComparison.Ordinal))
-        {
-            id = id.Substring(root2.Length + 1);
-        }
-
-        var lastDot = id.LastIndexOf('.');
-        var simple = lastDot >= 0 ? id.Substring(lastDot + 1) : id;
-
-        simple = Regex.Replace(simple, @"`(\d+)", m =>
-        {
-            var n = int.Parse(m.Groups[1].Value);
-            return $"<{string.Join(",", Enumerable.Range(1, n).Select(i => $"T{i}"))}>";
-        });
-
-        return simple;
-    }
-
-    /// <summary>
-    /// Shortens a fully‑qualified type for signature display (aliases + recursive generic argument formatting).
-    /// </summary>
-    private string ShortenSignatureType(string full)
-    {
-        if (string.IsNullOrWhiteSpace(full)) return string.Empty;
-
-        var s = full.Trim().Replace('{', '<').Replace('}', '>');
-        s = Regex.Replace(s, @"``(\d+)", m => $"T{int.Parse(m.Groups[1].Value) + 1}");
-        s = Regex.Replace(s, @"`(\d+)", m => $"T{int.Parse(m.Groups[1].Value) + 1}");
-
-        var lt = s.IndexOf('<');
-        if (lt < 0)
-        {
-            s = _aliasProvider.ApplyAliases(s);
-            if (s.Contains('.')) s = s.Split('.').Last();
-            s = s.Replace("System.", string.Empty);
-            return s;
-        }
-
-        var gt = FindMatchingAngle(s, lt);
-        if (gt < 0) return s;
-
-        var head = s.Substring(0, lt);
-        var inner = s.Substring(lt + 1, gt - lt - 1);
-        var tail = s.Substring(gt + 1);
-
-        head = _aliasProvider.ApplyAliases(head);
-        if (head.Contains('.')) head = head.Split('.').Last();
-        head = head.Replace("System.Collections.Generic.", string.Empty)
-                   .Replace("System.", string.Empty);
-
-        var args = SplitTopLevel(inner).Select(ShortenSignatureType);
-        var rebuilt = $"{head}<{string.Join(", ", args)}>";
-        return rebuilt + tail;
-
-        static int FindMatchingAngle(string str, int openIdx)
-        {
-            int depth = 0;
-            for (int i = openIdx; i < str.Length; i++)
-            {
-                var ch = str[i];
-                if (ch == '<') depth++;
-                else if (ch == '>')
-                {
-                    depth--;
-                    if (depth == 0) return i;
-                }
-            }
-            return -1;
-        }
-
-        static IEnumerable<string> SplitTopLevel(string s)
-        {
-            var depth = 0; int start = 0;
-            for (int i = 0; i < s.Length; i++)
-            {
-                var ch = s[i];
-                if (ch == '<') depth++;
-                else if (ch == '>') depth--;
-                else if (ch == ',' && depth == 0)
-                {
-                    yield return s.Substring(start, i - start).Trim();
-                    start = i + 1;
-                }
-            }
-            if (start <= s.Length) yield return s.Substring(start).Trim();
-        }
-    }
-
-    /// <summary>
     /// Builds a member table of contents (overload groups collapsed to first anchor).
     /// </summary>
     private string BuildMemberToc(IEnumerable<XMember> members)
@@ -795,7 +637,7 @@ public sealed class MarkdownRenderer
         foreach (var g in groups)
         {
             var first = g.First();
-            var label = MemberHeader(first);
+            var label = _signatureRenderer.RenderMemberHeader(first, _signatureStyle);
             var anchor = IdToAnchor(first.Id);
             sb.AppendLine($"- [{label}](#{anchor})");
         }
@@ -944,156 +786,6 @@ public sealed class MarkdownRenderer
         var id = typeCref.StartsWith("T:") ? typeCref.Substring(2) : typeCref;
         id = id.Replace('+', '.');
         return FileNameForPerType(id);
-    }
-
-    /// <summary>
-    /// Shortens a type cref for display (arity → placeholders, braces normalized, aliases applied).
-    /// </summary>
-    private string ShortenTypeName(string cref)
-    {
-#if NETSTANDARD2_0
-        var id = (cref.IndexOf(':') >= 0) ? cref.Split(new[] { ':' }, 2)[1] : cref;
-#else
-        var id = cref.Contains(':') ? cref.Split(':', 2)[1] : cref;
-#endif
-        var last = id.Split('.').LastOrDefault() ?? id;
-        last = Regex.Replace(last, @"`(\d+)", m =>
-        {
-            var n = int.Parse(m.Groups[1].Value);
-            return $"<{string.Join(",", Enumerable.Range(1, n).Select(i => $"T{i}"))}>";
-        });
-        last = last.Replace('{', '<').Replace('}', '>');
-        last = _aliasProvider.ApplyAliases(last);
-        return last;
-    }
-
-    /// <summary>
-    /// Generates a short label from a cref (type name or method name + simplified parameter list).
-    /// </summary>
-    private string ShortLabelFromCref(string cref)
-    {
-        if (string.IsNullOrWhiteSpace(cref))
-            return string.Empty;
-
-#if NETSTANDARD2_0
-        var parts = cref.Split(new[] { ':' }, 2);
-#else
-        var parts = cref.Split(':', 2);
-#endif
-        var kind = parts.Length == 2 ? parts[0] : "";
-        var id = parts.Length == 2 ? parts[1] : cref;
-
-        if (kind == "T")
-            return ShortTypeDisplay(id);
-
-        if (kind == "M")
-        {
-            var parenIdx = id.IndexOf('(');
-            var cut = parenIdx >= 0 ? id.LastIndexOf('.', parenIdx) : id.LastIndexOf('.');
-            var nameAndParams = cut >= 0 ? id.Substring(cut + 1) : id;
-            var paren = nameAndParams.IndexOf('(');
-#if NETSTANDARD2_0
-            var methodName = paren >= 0 ? nameAndParams.Substring(0, paren) : nameAndParams;
-#else
-            var methodName = paren >= 0 ? nameAndParams[..paren] : nameAndParams;
-#endif
-            methodName = Regex.Replace(methodName, @"``(\d+)", m2 =>
-            {
-                var n = int.Parse(m2.Groups[1].Value);
-                return $"<{string.Join(",", Enumerable.Range(1, n).Select(i => $"T{i}"))}>";
-            });
-
-            var paramList = (paren >= 0 && nameAndParams.EndsWith(")"))
-                ? nameAndParams.Substring(paren + 1, nameAndParams.Length - paren - 2)
-                : string.Empty;
-
-            static IEnumerable<string> SplitParams(string s)
-            {
-                var depth = 0; var start = 0;
-                for (int i = 0; i < s.Length; i++)
-                {
-                    var ch = s[i];
-                    if (ch == '{') depth++;
-                    else if (ch == '}') depth--;
-                    else if (ch == ',' && depth == 0)
-                    {
-                        yield return s.Substring(start, i - start).Trim();
-                        start = i + 1;
-                    }
-                }
-                if (s.Length > 0) yield return s.Substring(start).Trim();
-            }
-
-            static IEnumerable<string> SplitTopLevelGenericArgs(string s)
-            {
-                var depth = 0; var start = 0;
-                for (int i = 0; i < s.Length; i++)
-                {
-                    var ch = s[i];
-                    if (ch == '<') depth++;
-                    else if (ch == '>') depth--;
-                    else if (ch == ',' && depth == 0)
-                    {
-                        yield return s.Substring(start, i - start).Trim();
-                        start = i + 1;
-                    }
-                }
-                if (start <= s.Length) yield return s.Substring(start).Trim();
-            }
-
-            string FormatParam(string p)
-            {
-                p = p.Trim();
-                p = p.Replace('{', '<').Replace('}', '>');
-                p = _aliasProvider.ApplyAliases(p);
-
-                if (p.Contains('<') && p.Contains('>'))
-                {
-                    var lt = p.IndexOf('<');
-                    var gt = p.LastIndexOf('>');
-                    if (lt >= 0 && gt > lt)
-                    {
-#if NETSTANDARD2_0
-                        var head = p.Substring(0, lt + 1);
-                        var inner = p.Substring(lt + 1, gt - lt - 1);
-                        var tail = p.Substring(gt);
-#else
-                        var head = p[..(lt + 1)];
-                        var inner = p.Substring(lt + 1, gt - lt - 1);
-                        var tail = p[gt..];
-#endif
-                        var trimmedArgs = SplitTopLevelGenericArgs(inner)
-                            .Select(x => x.Contains('<')
-                                ? Regex.Replace(x, @"(?<![A-Za-z0-9_])([A-ZaZ0-9_.]+)(?=\s*<)", m => m.Groups[1].Value.Split('.').Last())
-                                : x.Split('.').Last()
-                            );
-                        var newInner = string.Join(", ", trimmedArgs);
-                        p = head + newInner + tail;
-                    }
-                }
-
-                if (!p.Contains('<'))
-                    p = p.Split('.').Last();
-                return p;
-            }
-
-            var formattedParams = string.IsNullOrWhiteSpace(paramList)
-                ? string.Empty
-                : string.Join(", ", SplitParams(paramList).Select(FormatParam));
-
-            return string.IsNullOrEmpty(formattedParams)
-                ? $"{methodName}()"
-                : $"{methodName}({formattedParams})";
-        }
-
-#if NETSTANDARD2_0
-        if (id.Contains("."))
-            return id.Substring(id.LastIndexOf('.') + 1);
-#else
-        if (id.Contains('.'))
-            return id[(id.LastIndexOf('.') + 1)..];
-#endif
-        return id;
     }
 
     // === XML → Markdown normalization ===
@@ -1284,9 +976,9 @@ public sealed class MarkdownRenderer
         sb.AppendLine($"<a id=\"{IdToAnchor(m.Id)}\"></a>");
 
         if (asOverload)
-            sb.AppendLine($"- `{MemberHeader(m)}`");
+            sb.AppendLine($"- `{_signatureRenderer.RenderMemberHeader(m, _signatureStyle)}`");
         else
-            sb.AppendLine($"## {MemberHeader(m)}");
+            sb.AppendLine($"## {_signatureRenderer.RenderMemberHeader(m, _signatureStyle)}");
 
         var ms = NormalizeXmlToMarkdown(memberElement.Element("summary"));
         if (!string.IsNullOrWhiteSpace(ms))

--- a/Xml2Doc/src/Xml2Doc.Core/README.md
+++ b/Xml2Doc/src/Xml2Doc.Core/README.md
@@ -177,6 +177,23 @@ kind prefix. For other routing rules, implement `IExternalSymbolResolver` and pa
 `ExternalSymbolResolver`. If the provider declines a symbol, Xml2Doc preserves its existing
 internal-link fallback.
 
+Signature formatting is extracted behind `ISignatureRenderer`. The default style preserves the
+existing headings and cref labels. Optional detail can be enabled without replacing the service:
+
+```csharp
+var options = new RendererOptions(
+    SignatureStyle: new SignatureStyle(
+        IncludeParamNames: true,
+        IncludeConstraints: true,
+        IncludeDefaultValues: true));
+```
+
+With parameter names enabled, documented indexer properties use C# `this[...]` syntax. Parameter
+modifiers, default values, and generic constraints are read from optional `modifier`, `default`,
+and `constraint` attributes when those metadata values are available. Standard compiler XML does
+not include every source-level signature detail, so consumers that obtain metadata elsewhere can
+implement `ISignatureRenderer` and pass it as `SignatureRenderer`.
+
 ## Tests & Snapshots
 
 - Snapshot tests assert stable Markdown for representative inputs.

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -4,6 +4,7 @@ using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
 using Xml2Doc.Core.AutoLinking;
 using Xml2Doc.Core.Linking;
+using Xml2Doc.Core.Signatures;
 
 namespace Xml2Doc.Core
 {
@@ -161,6 +162,14 @@ namespace Xml2Doc.Core
     /// <paramref name="ExternalDocs"/> is set, a
     /// <see cref="BaseUrlExternalSymbolResolver"/> is used.
     /// </param>
+    /// <param name="SignatureStyle">
+    /// Optional controls for parameter names, generic constraints, and default values.
+    /// The default preserves existing signature output.
+    /// </param>
+    /// <param name="SignatureRenderer">
+    /// Optional signature and label renderer. When omitted, Xml2Doc uses
+    /// <see cref="DefaultSignatureRenderer"/>.
+    /// </param>
     /// <remarks>
     /// Example:
     /// <code><![CDATA[
@@ -214,9 +223,73 @@ namespace Xml2Doc.Core
         Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter = null,
         IAutoLinker? AutoLinker = null,
         LinkPolicy LinkPolicy = LinkPolicy.InternalOnly,
-        IExternalSymbolResolver? ExternalSymbolResolver = null
+        IExternalSymbolResolver? ExternalSymbolResolver = null,
+        SignatureStyle? SignatureStyle = null,
+        ISignatureRenderer? SignatureRenderer = null
     )
     {
+        /// <summary>
+        /// Preserves the constructor signature published with external cref resolution.
+        /// </summary>
+        public RendererOptions(
+            FileNameMode FileNameMode,
+            string? RootNamespaceToTrim,
+            string CodeBlockLanguage,
+            bool TrimRootNamespaceInFileNames,
+            AnchorAlgorithm AnchorAlgorithm,
+            string? TemplatePath,
+            string? FrontMatterPath,
+            bool AutoLink,
+            string? AliasMapPath,
+            string? ExternalDocs,
+            bool EmitToc,
+            bool EmitNamespaceIndex,
+            bool BasenameOnly,
+            int? ParallelDegree,
+            bool GenerateIndex,
+            bool PruneStaleFiles,
+            string? ManifestIdentity,
+            LineEndingStyle LineEndings,
+            Action<string>? WarningSink,
+            IAliasProvider? AliasProvider,
+            IAnchorGenerator? AnchorGenerator,
+            ITemplateRenderer? TemplateRenderer,
+            Func<TemplateRenderContext, IReadOnlyDictionary<string, object?>>? FrontMatter,
+            IAutoLinker? AutoLinker,
+            LinkPolicy LinkPolicy,
+            IExternalSymbolResolver? ExternalSymbolResolver)
+            : this(
+                FileNameMode,
+                RootNamespaceToTrim,
+                CodeBlockLanguage,
+                TrimRootNamespaceInFileNames,
+                AnchorAlgorithm,
+                TemplatePath,
+                FrontMatterPath,
+                AutoLink,
+                AliasMapPath,
+                ExternalDocs,
+                EmitToc,
+                EmitNamespaceIndex,
+                BasenameOnly,
+                ParallelDegree,
+                GenerateIndex,
+                PruneStaleFiles,
+                ManifestIdentity,
+                LineEndings,
+                WarningSink,
+                AliasProvider,
+                AnchorGenerator,
+                TemplateRenderer,
+                FrontMatter,
+                AutoLinker,
+                LinkPolicy,
+                ExternalSymbolResolver,
+                SignatureStyle: null,
+                SignatureRenderer: null)
+        {
+        }
+
         /// <summary>
         /// Preserves the constructor signature published with auto-linker injection.
         /// </summary>

--- a/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/RendererOptions.cs
@@ -164,6 +164,7 @@ namespace Xml2Doc.Core
     /// </param>
     /// <param name="SignatureStyle">
     /// Optional controls for parameter names, generic constraints, and default values.
+    /// Constraint output also uses documented generic parameter names in the signature.
     /// The default preserves existing signature output.
     /// </param>
     /// <param name="SignatureRenderer">

--- a/Xml2Doc/src/Xml2Doc.Core/Signatures/DefaultSignatureRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Signatures/DefaultSignatureRenderer.cs
@@ -129,10 +129,7 @@ public sealed class DefaultSignatureRenderer : ISignatureRenderer
             var tail = value.Substring(close);
             var arguments = SplitTopLevel(inner, '<', '>')
                 .Select(argument => argument.IndexOf('<') >= 0
-                    ? Regex.Replace(
-                        argument,
-                        @"(?<![A-Za-z0-9_])([A-ZaZ0-9_.]+)(?=\s*<)",
-                        match => match.Groups[1].Value.Split('.').Last())
+                    ? argument
                     : argument.Split('.').Last());
             value = head + string.Join(", ", arguments) + tail;
         }

--- a/Xml2Doc/src/Xml2Doc.Core/Signatures/DefaultSignatureRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Signatures/DefaultSignatureRenderer.cs
@@ -1,0 +1,307 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xml2Doc.Core.Aliasing;
+using Xml2Doc.Core.Models;
+
+namespace Xml2Doc.Core.Signatures;
+
+/// <summary>Default depth-aware C#-style signature renderer.</summary>
+public sealed class DefaultSignatureRenderer : ISignatureRenderer
+{
+    private readonly IAliasProvider _aliasProvider;
+    private readonly string? _rootNamespaceToTrim;
+
+    /// <summary>Creates a signature renderer with optional aliases and root trimming.</summary>
+    /// <param name="aliasProvider">Alias provider used for signature types.</param>
+    /// <param name="rootNamespaceToTrim">Optional root namespace removed from type headings.</param>
+    public DefaultSignatureRenderer(
+        IAliasProvider? aliasProvider = null,
+        string? rootNamespaceToTrim = null)
+    {
+        _aliasProvider = aliasProvider ?? DefaultAliasProvider.Instance;
+        _rootNamespaceToTrim = rootNamespaceToTrim;
+    }
+
+    /// <inheritdoc />
+    public string RenderTypeName(string typeId)
+    {
+        if (typeId.IndexOf('{') >= 0 ||
+            typeId.IndexOf('}') >= 0 ||
+            typeId.IndexOf('<') >= 0)
+        {
+            var display = FormatType(typeId, Array.Empty<string>());
+            return TrimRootNamespace(display);
+        }
+
+        var id = TrimRootNamespace(typeId);
+        var lastDot = id.LastIndexOf('.');
+        var simple = lastDot >= 0 ? id.Substring(lastDot + 1) : id;
+        return ExpandGenericArity(simple, Array.Empty<string>());
+    }
+
+    /// <inheritdoc />
+    public string RenderMemberHeader(XMember member, SignatureStyle style)
+    {
+        if (member is null)
+            throw new ArgumentNullException(nameof(member));
+        if (style is null)
+            throw new ArgumentNullException(nameof(style));
+
+        var typeParameters = member.Element.Elements("typeparam").ToArray();
+        var genericNames = style.IncludeConstraints
+            ? typeParameters
+                .Select(element => (string?)element.Attribute("name"))
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => name!)
+                .ToArray()
+            : Array.Empty<string>();
+        var name = RenderMemberName(member, style, genericNames);
+        var constraints = style.IncludeConstraints
+            ? RenderConstraints(typeParameters)
+            : string.Empty;
+        return $"{KindToWord(member.Kind)}: {name}{constraints}";
+    }
+
+    /// <inheritdoc />
+    public string RenderCrefLabel(string cref)
+    {
+        if (string.IsNullOrWhiteSpace(cref))
+            return string.Empty;
+
+        var parts = cref.Split(new[] { ':' }, 2);
+        var kind = parts.Length == 2 ? parts[0] : string.Empty;
+        var id = parts.Length == 2 ? parts[1] : cref;
+        if (kind == "T")
+            return RenderTypeName(id);
+
+        if (kind == "M")
+        {
+            var label = RenderMemberName(
+                id,
+                Array.Empty<XElement>(),
+                SignatureStyle.Default,
+                Array.Empty<string>());
+            return id.IndexOf('(') >= 0 ? label : label + "()";
+        }
+
+        var lastDot = id.LastIndexOf('.');
+        return lastDot >= 0 ? id.Substring(lastDot + 1) : id;
+    }
+
+    private string RenderMemberName(
+        XMember member,
+        SignatureStyle style,
+        IReadOnlyList<string> genericNames) =>
+        RenderMemberName(
+            member.Id,
+            member.Element.Elements("param").ToArray(),
+            style,
+            genericNames,
+            member.Kind);
+
+    private string RenderMemberName(
+        string id,
+        IReadOnlyList<XElement> parameters,
+        SignatureStyle style,
+        IReadOnlyList<string> genericNames,
+        string kind = "M")
+    {
+        var parenIndex = id.IndexOf('(');
+        var cut = parenIndex >= 0
+            ? id.LastIndexOf('.', parenIndex)
+            : id.LastIndexOf('.');
+        var nameAndParameters = cut >= 0 ? id.Substring(cut + 1) : id;
+        var openParen = nameAndParameters.IndexOf('(');
+        var closeParen = nameAndParameters.EndsWith(")", StringComparison.Ordinal)
+            ? nameAndParameters.Length - 1
+            : -1;
+        var name = openParen >= 0
+            ? nameAndParameters.Substring(0, openParen)
+            : nameAndParameters;
+        name = ExpandGenericArity(name, genericNames);
+
+        var parameterList = openParen >= 0 && closeParen > openParen
+            ? nameAndParameters.Substring(openParen + 1, closeParen - openParen - 1)
+            : string.Empty;
+        var types = string.IsNullOrWhiteSpace(parameterList)
+            ? Array.Empty<string>()
+            : SplitTopLevel(parameterList, '{', '}').ToArray();
+        var renderedParameters = types
+            .Select((type, index) => RenderParameter(
+                type,
+                index < parameters.Count ? parameters[index] : null,
+                style,
+                genericNames))
+            .ToArray();
+
+        if (kind == "P" &&
+            string.Equals(name, "Item", StringComparison.Ordinal) &&
+            renderedParameters.Length > 0 &&
+            (style.IncludeParamNames || style.IncludeDefaultValues))
+        {
+            return $"this[{string.Join(", ", renderedParameters)}]";
+        }
+
+        return openParen >= 0
+            ? $"{name}({string.Join(", ", renderedParameters)})"
+            : name;
+    }
+
+    private string RenderParameter(
+        string type,
+        XElement? parameter,
+        SignatureStyle style,
+        IReadOnlyList<string> genericNames)
+    {
+        var includeName = style.IncludeParamNames || style.IncludeDefaultValues;
+        var modifier = includeName
+            ? (string?)parameter?.Attribute("modifier")
+            : null;
+        if (includeName &&
+            string.IsNullOrWhiteSpace(modifier) &&
+            type.EndsWith("@", StringComparison.Ordinal))
+            modifier = "ref";
+
+        var normalizedType = includeName && type.EndsWith("@", StringComparison.Ordinal)
+            ? type.Substring(0, type.Length - 1)
+            : type;
+        var result = FormatType(normalizedType, genericNames);
+        if (!string.IsNullOrWhiteSpace(modifier))
+            result = modifier + " " + result;
+
+        var name = (string?)parameter?.Attribute("name");
+        if (includeName && !string.IsNullOrWhiteSpace(name))
+            result += " " + name;
+
+        var defaultValue = (string?)parameter?.Attribute("default");
+        if (style.IncludeDefaultValues && !string.IsNullOrWhiteSpace(defaultValue))
+            result += " = " + defaultValue;
+
+        return result;
+    }
+
+    private static string RenderConstraints(IEnumerable<XElement> typeParameters)
+    {
+        var constraints = typeParameters
+            .Select(element => new
+            {
+                Name = (string?)element.Attribute("name"),
+                Constraint = (string?)element.Attribute("constraint")
+            })
+            .Where(item =>
+                !string.IsNullOrWhiteSpace(item.Name) &&
+                !string.IsNullOrWhiteSpace(item.Constraint))
+            .Select(item => $" where {item.Name} : {item.Constraint}");
+        return string.Concat(constraints);
+    }
+
+    private string FormatType(string full, IReadOnlyList<string> genericNames)
+    {
+        if (string.IsNullOrWhiteSpace(full))
+            return string.Empty;
+
+        var value = full.Trim().Replace('{', '<').Replace('}', '>');
+        value = Regex.Replace(value, @"``(\d+)", match =>
+        {
+            var index = int.Parse(match.Groups[1].Value);
+            return index < genericNames.Count ? genericNames[index] : $"T{index + 1}";
+        });
+        value = Regex.Replace(value, @"`(\d+)", match =>
+            $"T{int.Parse(match.Groups[1].Value) + 1}");
+
+        var open = value.IndexOf('<');
+        if (open < 0)
+            return ShortenSimpleType(value);
+
+        var close = FindMatchingAngle(value, open);
+        if (close < 0)
+            return value;
+
+        var head = ShortenSimpleType(value.Substring(0, open));
+        var inner = value.Substring(open + 1, close - open - 1);
+        var tail = value.Substring(close + 1);
+        var arguments = SplitTopLevel(inner, '<', '>')
+            .Select(argument => FormatType(argument, genericNames));
+        return $"{head}<{string.Join(", ", arguments)}>{tail}";
+    }
+
+    private string ShortenSimpleType(string value)
+    {
+        var result = _aliasProvider.ApplyAliases(value);
+        if (result.IndexOf('.') >= 0)
+            result = result.Split('.').Last();
+        return result.Replace("System.Collections.Generic.", string.Empty)
+            .Replace("System.", string.Empty);
+    }
+
+    private string TrimRootNamespace(string value)
+    {
+        if (!string.IsNullOrWhiteSpace(_rootNamespaceToTrim) &&
+            value.StartsWith(_rootNamespaceToTrim + ".", StringComparison.Ordinal))
+        {
+            return value.Substring(_rootNamespaceToTrim.Length + 1);
+        }
+
+        return value;
+    }
+
+    private static string ExpandGenericArity(
+        string value,
+        IReadOnlyList<string> genericNames) =>
+        Regex.Replace(value, @"``?(\d+)", match =>
+        {
+            var count = int.Parse(match.Groups[1].Value);
+            var names = genericNames.Count == count
+                ? genericNames
+                : Enumerable.Range(1, count).Select(index => $"T{index}");
+            return $"<{string.Join(",", names)}>";
+        });
+
+    private static int FindMatchingAngle(string value, int openIndex)
+    {
+        var depth = 0;
+        for (var index = openIndex; index < value.Length; index++)
+        {
+            if (value[index] == '<')
+                depth++;
+            else if (value[index] == '>' && --depth == 0)
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static IEnumerable<string> SplitTopLevel(
+        string value,
+        char open,
+        char close)
+    {
+        var depth = 0;
+        var start = 0;
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (value[index] == open)
+                depth++;
+            else if (value[index] == close)
+                depth--;
+            else if (value[index] == ',' && depth == 0)
+            {
+                yield return value.Substring(start, index - start).Trim();
+                start = index + 1;
+            }
+        }
+
+        if (start <= value.Length)
+            yield return value.Substring(start).Trim();
+    }
+
+    private static string KindToWord(string kind) => kind switch
+    {
+        "M" => "Method",
+        "P" => "Property",
+        "F" => "Field",
+        "E" => "Event",
+        "T" => "Type",
+        _ => kind
+    };
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Signatures/DefaultSignatureRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Signatures/DefaultSignatureRenderer.cs
@@ -75,17 +75,71 @@ public sealed class DefaultSignatureRenderer : ISignatureRenderer
             return RenderTypeName(id);
 
         if (kind == "M")
-        {
-            var label = RenderMemberName(
-                id,
-                Array.Empty<XElement>(),
-                SignatureStyle.Default,
-                Array.Empty<string>());
-            return id.IndexOf('(') >= 0 ? label : label + "()";
-        }
+            return RenderLegacyMethodCrefLabel(id);
 
         var lastDot = id.LastIndexOf('.');
         return lastDot >= 0 ? id.Substring(lastDot + 1) : id;
+    }
+
+    private string RenderLegacyMethodCrefLabel(string id)
+    {
+        var parenIndex = id.IndexOf('(');
+        var cut = parenIndex >= 0
+            ? id.LastIndexOf('.', parenIndex)
+            : id.LastIndexOf('.');
+        var nameAndParameters = cut >= 0 ? id.Substring(cut + 1) : id;
+        var paren = nameAndParameters.IndexOf('(');
+        var methodName = paren >= 0
+            ? nameAndParameters.Substring(0, paren)
+            : nameAndParameters;
+        methodName = Regex.Replace(methodName, @"``(\d+)", match =>
+        {
+            var count = int.Parse(match.Groups[1].Value);
+            return $"<{string.Join(",", Enumerable.Range(1, count).Select(index => $"T{index}"))}>";
+        });
+
+        var parameterList = paren >= 0 &&
+                            nameAndParameters.EndsWith(")", StringComparison.Ordinal)
+            ? nameAndParameters.Substring(
+                paren + 1,
+                nameAndParameters.Length - paren - 2)
+            : string.Empty;
+        var parameters = string.IsNullOrWhiteSpace(parameterList)
+            ? string.Empty
+            : string.Join(", ",
+                SplitTopLevel(parameterList, '{', '}')
+                    .Select(FormatLegacyCrefParameter));
+
+        return string.IsNullOrEmpty(parameters)
+            ? $"{methodName}()"
+            : $"{methodName}({parameters})";
+    }
+
+    private string FormatLegacyCrefParameter(string parameter)
+    {
+        var value = _aliasProvider.ApplyAliases(
+            parameter.Trim().Replace('{', '<').Replace('}', '>'));
+        var open = value.IndexOf('<');
+        var close = value.LastIndexOf('>');
+
+        if (open >= 0 && close > open)
+        {
+            var head = value.Substring(0, open + 1);
+            var inner = value.Substring(open + 1, close - open - 1);
+            var tail = value.Substring(close);
+            var arguments = SplitTopLevel(inner, '<', '>')
+                .Select(argument => argument.IndexOf('<') >= 0
+                    ? Regex.Replace(
+                        argument,
+                        @"(?<![A-Za-z0-9_])([A-ZaZ0-9_.]+)(?=\s*<)",
+                        match => match.Groups[1].Value.Split('.').Last())
+                    : argument.Split('.').Last());
+            value = head + string.Join(", ", arguments) + tail;
+        }
+
+        if (value.IndexOf('<') < 0)
+            value = value.Split('.').Last();
+        return value;
     }
 
     private string RenderMemberName(

--- a/Xml2Doc/src/Xml2Doc.Core/Signatures/ISignatureRenderer.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Signatures/ISignatureRenderer.cs
@@ -1,0 +1,16 @@
+using Xml2Doc.Core.Models;
+
+namespace Xml2Doc.Core.Signatures;
+
+/// <summary>Formats documented types, members, and cref labels for Markdown output.</summary>
+public interface ISignatureRenderer
+{
+    /// <summary>Formats a type documentation identifier for display.</summary>
+    string RenderTypeName(string typeId);
+
+    /// <summary>Formats a member heading, including its readable member kind.</summary>
+    string RenderMemberHeader(XMember member, SignatureStyle style);
+
+    /// <summary>Formats the visible label for an XML documentation cref.</summary>
+    string RenderCrefLabel(string cref);
+}

--- a/Xml2Doc/src/Xml2Doc.Core/Signatures/SignatureStyle.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Signatures/SignatureStyle.cs
@@ -2,7 +2,10 @@ namespace Xml2Doc.Core.Signatures;
 
 /// <summary>Controls optional detail in rendered member signatures.</summary>
 /// <param name="IncludeParamNames">Include documented parameter names.</param>
-/// <param name="IncludeConstraints">Include available generic parameter constraints.</param>
+/// <param name="IncludeConstraints">
+/// Include available generic parameter constraints and use documented type-parameter
+/// names instead of generated placeholders so each <c>where</c> clause matches its signature.
+/// </param>
 /// <param name="IncludeDefaultValues">Include available parameter default values.</param>
 public sealed record SignatureStyle(
     bool IncludeParamNames = false,

--- a/Xml2Doc/src/Xml2Doc.Core/Signatures/SignatureStyle.cs
+++ b/Xml2Doc/src/Xml2Doc.Core/Signatures/SignatureStyle.cs
@@ -1,0 +1,14 @@
+namespace Xml2Doc.Core.Signatures;
+
+/// <summary>Controls optional detail in rendered member signatures.</summary>
+/// <param name="IncludeParamNames">Include documented parameter names.</param>
+/// <param name="IncludeConstraints">Include available generic parameter constraints.</param>
+/// <param name="IncludeDefaultValues">Include available parameter default values.</param>
+public sealed record SignatureStyle(
+    bool IncludeParamNames = false,
+    bool IncludeConstraints = false,
+    bool IncludeDefaultValues = false)
+{
+    /// <summary>Compatibility style matching Xml2Doc's existing output.</summary>
+    public static SignatureStyle Default { get; } = new();
+}

--- a/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/AliasingTests.cs
@@ -10,6 +10,7 @@ using Xml2Doc.Core.Anchoring;
 using Xml2Doc.Core.Templates;
 using Xml2Doc.Core.AutoLinking;
 using Xml2Doc.Core.Linking;
+using Xml2Doc.Core.Signatures;
 using Xml2Doc.Sample;
 using Xunit;
 
@@ -66,6 +67,24 @@ public class AliasingTests
             .GetConstructor(
                 anchorGeneratorSignature
                     .Concat(new[] { typeof(ITemplateRenderer) })
+                    .ToArray())
+            .ShouldNotBeNull();
+
+        typeof(RendererOptions)
+            .GetConstructor(
+                anchorGeneratorSignature
+                    .Concat(new[]
+                    {
+                        typeof(ITemplateRenderer),
+                        typeof(Func<
+                            TemplateRenderContext,
+                            IReadOnlyDictionary<string, object?>>),
+                        typeof(IAutoLinker),
+                        typeof(LinkPolicy),
+                        typeof(IExternalSymbolResolver),
+                        typeof(SignatureStyle),
+                        typeof(ISignatureRenderer)
+                    })
                     .ToArray())
             .ShouldNotBeNull();
 

--- a/Xml2Doc/tests/Xml2Doc.Tests/SignatureRendererTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/SignatureRendererTests.cs
@@ -1,0 +1,160 @@
+using Shouldly;
+using System.Xml.Linq;
+using Xml2Doc.Core;
+using Xml2Doc.Core.Models;
+using Xml2Doc.Core.Signatures;
+using Xunit;
+
+namespace Xml2Doc.Tests;
+
+public class SignatureRendererTests
+{
+    [Fact]
+    public void DefaultStyle_PreservesNestedGenericSignature()
+    {
+        var member = Member(
+            "M:Temp.Nested.Transform``2(System.Collections.Generic.List{System.Collections.Generic.Dictionary{``0,System.Collections.Generic.List{``1}}})");
+
+        var result = new DefaultSignatureRenderer()
+            .RenderMemberHeader(member, SignatureStyle.Default);
+
+        result.ShouldBe(
+            "Method: Transform<T1,T2>(List<Dictionary<T1, List<T2>>>)");
+    }
+
+    [Fact]
+    public void DetailedStyle_RendersNamesDefaultsModifiersAndConstraints()
+    {
+        var member = Member(
+            "M:Temp.Factory.Create``1(System.Int32,System.String[],``0@)",
+            new XElement("typeparam",
+                new XAttribute("name", "T"),
+                new XAttribute("constraint", "class, new()")),
+            new XElement("param",
+                new XAttribute("name", "count"),
+                new XAttribute("default", "42")),
+            new XElement("param",
+                new XAttribute("name", "values"),
+                new XAttribute("modifier", "params")),
+            new XElement("param",
+                new XAttribute("name", "result")));
+        var style = new SignatureStyle(
+            IncludeParamNames: true,
+            IncludeConstraints: true,
+            IncludeDefaultValues: true);
+
+        var result = new DefaultSignatureRenderer()
+            .RenderMemberHeader(member, style);
+
+        result.ShouldBe(
+            "Method: Create<T>(int count = 42, params string[] values, ref T result) where T : class, new()");
+    }
+
+    [Fact]
+    public void ParameterNames_UseCSharpIndexerSyntax()
+    {
+        var member = Member(
+            "P:Temp.Collection.Item(System.Int32)",
+            new XElement("param", new XAttribute("name", "index")));
+
+        var result = new DefaultSignatureRenderer().RenderMemberHeader(
+            member,
+            new SignatureStyle(IncludeParamNames: true));
+
+        result.ShouldBe("Property: this[int index]");
+    }
+
+    [Fact]
+    public void DefaultStyle_PreservesIndexerCompatibility()
+    {
+        var member = Member(
+            "P:Temp.Collection.Item(System.Int32)",
+            new XElement("param", new XAttribute("name", "index")));
+
+        new DefaultSignatureRenderer()
+            .RenderMemberHeader(member, SignatureStyle.Default)
+            .ShouldBe("Property: Item(int)");
+    }
+
+    [Fact]
+    public void Renderer_UsesCustomSignatureService()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, """
+            <doc><members>
+              <member name="T:Temp.Widget">
+                <summary>See <see cref="T:Temp.Other"/>.</summary>
+              </member>
+              <member name="M:Temp.Widget.Run(System.String)">
+                <summary>Runs.</summary>
+              </member>
+            </members></doc>
+            """);
+
+        try
+        {
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(path);
+            var markdown = new MarkdownRenderer(
+                model,
+                new RendererOptions(SignatureRenderer: new PrefixSignatureRenderer()))
+                .RenderToString();
+
+            markdown.ShouldContain("# type:Temp.Widget");
+            markdown.ShouldContain("## member:M:Temp.Widget.Run(System.String)");
+            markdown.ShouldContain("[cref:T:Temp.Other]");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Renderer_AppliesConfiguredSignatureStyle()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, """
+            <doc><members>
+              <member name="T:Temp.Collection"><summary>A collection.</summary></member>
+              <member name="P:Temp.Collection.Item(System.Int32)">
+                <summary>Gets an item.</summary>
+                <param name="index">The index.</param>
+              </member>
+            </members></doc>
+            """);
+
+        try
+        {
+            var model = Xml2Doc.Core.Models.Xml2Doc.Load(path);
+            var markdown = new MarkdownRenderer(
+                model,
+                new RendererOptions(
+                    SignatureStyle: new SignatureStyle(
+                        IncludeParamNames: true)))
+                .RenderToString();
+
+            markdown.ShouldContain("## Property: this[int index]");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static XMember Member(string name, params XElement[] children)
+    {
+        var element = new XElement("member", new XAttribute("name", name));
+        element.Add(children);
+        return new XMember(name, element);
+    }
+
+    private sealed class PrefixSignatureRenderer : ISignatureRenderer
+    {
+        public string RenderTypeName(string typeId) => "type:" + typeId;
+
+        public string RenderMemberHeader(XMember member, SignatureStyle style) =>
+            "member:" + member.Name;
+
+        public string RenderCrefLabel(string cref) => "cref:" + cref;
+    }
+}

--- a/Xml2Doc/tests/Xml2Doc.Tests/SignatureRendererTests.cs
+++ b/Xml2Doc/tests/Xml2Doc.Tests/SignatureRendererTests.cs
@@ -23,6 +23,18 @@ public class SignatureRendererTests
     }
 
     [Fact]
+    public void DefaultCrefLabel_PreservesLegacyNestedParameterQualification()
+    {
+        const string cref =
+            "M:Xml2Doc.Sample.GenericPlayground.Flatten(System.Collections.Generic.IEnumerable{System.Collections.Generic.IEnumerable{Xml2Doc.Sample.XItem}})";
+
+        new DefaultSignatureRenderer()
+            .RenderCrefLabel(cref)
+            .ShouldBe(
+                "Flatten(System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<Xml2Doc.Sample.XItem>>)");
+    }
+
+    [Fact]
     public void DetailedStyle_RendersNamesDefaultsModifiersAndConstraints()
     {
         var member = Member(


### PR DESCRIPTION
## Summary

- introduce public `ISignatureRenderer`, `DefaultSignatureRenderer`, and `SignatureStyle`
- move type, member-heading, and cref-label formatting out of `MarkdownRenderer`
- preserve the existing default signature output
- add opt-in parameter names, default values, modifiers, and generic constraints
- render documented indexers as C# `this[...]` when parameter detail is enabled
- support custom signature rendering through `RendererOptions.SignatureRenderer`
- preserve previously published `RendererOptions` constructor signatures
- add nested-generic parity, indexer, modifier, default-value, constraint, and injection tests
- document which source-level details require additional XML metadata or a custom renderer

## Why

Signature and label formatting was embedded in `MarkdownRenderer`, which prevented consumers from changing signature presentation and made advanced forms difficult to extend safely.

## Compatibility

`SignatureStyle.Default` preserves the existing output contract. Enhanced details are opt-in. Existing aliases, filenames, anchors, and link destinations remain under their current services and options.

Standard compiler XML does not contain every source-level modifier, default value, or constraint. The built-in renderer consumes optional `modifier`, `default`, and `constraint` metadata when available; consumers can inject `ISignatureRenderer` when metadata comes from another source.

## Validation

- `git diff --check`
- focused default-parity coverage for nested generics and indexers
- enhanced-style coverage for names, modifiers, defaults, and constraints
- custom-service integration coverage
- constructor compatibility coverage updated
- GitHub Actions is the authoritative .NET and snapshot validation because this workspace has no .NET SDK

Closes #40
Refs #43
Refs #44