### PR TITLE
Update documentation for 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,126 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.4.0] - Unreleased
+## [2.1.0] - Unreleased
+
+### Added
+
+- Pluggable rendering services for Core consumers:
+  - `IAnchorGenerator` for custom heading and member anchors.
+  - `IAliasProvider` for configurable type-name aliases.
+  - `ITemplateRenderer` and a per-document front-matter callback.
+  - `IAutoLinker` for safe free-text symbol linking.
+  - `IExternalSymbolResolver` and `LinkPolicy` for unresolved cref targets.
+  - `ISignatureRenderer` and `SignatureStyle` for parameter names, generic constraints,
+    default values, and indexer formatting.
+- Built-in file templates and deterministic YAML front matter.
+- Optional auto-linking that protects fenced code, inline code, existing links, and partial
+  identifiers.
+- External documentation fallback using a configurable base URL.
+
+### Changed
+
+- Rendering now routes anchors, aliases, links, templates, and signatures through the same
+  replaceable services used by the built-in implementations.
+- Default rendering remains compatible with the `2.0.x` baseline unless a new option or custom
+  service is explicitly selected.
+
+### Tests
+
+- Added a per-type/single-file link-routing matrix for every built-in anchor algorithm.
+- Added parity coverage for emitted anchors and generated link targets.
+- Added integration coverage for every custom rendering service and auto-link safety boundaries.
+
+---
+
+## [2.0.3](https://github.com/mod-posh/Xml2Doc/releases/tag/2.0.3) - 2026-08-15
+
+### Added
+
+- Cross-project XML documentation discovery for `<inheritdoc />`, including automatic project
+  reference XML loading and explicit `Xml2Doc_ReferenceXml` items.
+- Portable output-ownership manifests that remain valid when a repository is moved to a different
+  checkout path.
+- Output ledgers that allow incremental MSBuild execution to detect and regenerate missing
+  Markdown files.
+
+### Fixed
+
+- `<see langword="..."/>` now renders its language keyword correctly while preserving attribute
+  precedence for existing `<see cref="..."/>` behavior.
+- `<inheritdoc />` now resolves inherited documentation for unique members, overloads, interfaces,
+  and referenced projects without mutating the source model.
+- Missing generated Markdown invalidates the MSBuild output stamp and is recreated on the next
+  build.
+- Ownership manifests migrate safe `2.0.x` entries without authorizing traversal or deletion
+  outside the current output root.
+
+### Changed
+
+- Manifest files are deterministic and portable; transaction directories remain local staging
+  state and are removed after successful cleanup.
+- Unresolved inheritance targets and missing explicitly configured reference XML files are reported
+  as non-fatal MSBuild warnings.
+
+---
+
+## [2.0.2](https://github.com/mod-posh/Xml2Doc/releases/tag/2.0.2) - 2026-08-14
+
+### Fixed
+
+- Corrected the `Xml2Doc.MSBuild` NuGet layout so `Xml2Doc.Core.dll` and other required runtime
+  dependencies are packaged beside the `net472` and `net8.0` task assemblies.
+- Fixed clean-consumer builds that previously failed with `FileNotFoundException` when MSBuild
+  loaded `Xml2Doc.Core`.
+- Fixed package integration commands so they execute from the generated consumer project directory.
+- Added the cross-platform `ZipFile` assembly loading required by package inspection.
+
+### Tests
+
+- Added package-layout assertions for both task target frameworks.
+- Added a clean .NET 9 consumer integration test that restores only the local
+  `Xml2Doc.MSBuild` package and verifies Markdown generation.
+- Suppressed the expected NuGet dependency-group warning after validating the self-contained task
+  package layout.
+
+---
+
+## [2.0.1](https://github.com/mod-posh/Xml2Doc/releases/tag/2.0.1) - 2026-08-14
+
+### Changed
+
+- Restricted NuGet publishing to milestone releases and tightened release-workflow permissions.
+- Updated package versions to `2.0.1`.
+
+### Known issue
+
+- The published `Xml2Doc.MSBuild` package did not include `Xml2Doc.Core.dll` beside its task
+  assemblies. Clean consumers could restore successfully but fail during `dotnet build`.
+  This packaging defect was corrected in `2.0.2`.
+
+---
+
+## [2.0.0](https://github.com/mod-posh/Xml2Doc/releases/tag/2.0.0) - 2026-08-13
+
+### Added
+
+- Explicit `lf`, `crlf`, and `native` line-ending policies across Core, CLI, and MSBuild.
+- `--line-endings` for the CLI and `Xml2Doc_LineEndings` for MSBuild consumers.
+- Cross-platform tests covering line endings and UTF-8 output without a byte-order mark.
+
+### Changed
+
+- Generated Markdown now uses LF on every platform by default for deterministic output.
+- Final output normalization is applied consistently across per-type and single-file modes.
+
+### Breaking
+
+- The default changed from platform-native line endings to LF. Windows consumers that require the
+  previous byte-level behavior must select `crlf` or `native` explicitly.
+
+---
+
+## [1.4.0](https://github.com/mod-posh/Xml2Doc/releases/tag/1.4.0) - 2026-08-13
 
 ### Added
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <RepositoryType>git</RepositoryType>
 
     <!-- Version: set once for all (override per project if needed) -->
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <!-- Licensing (metadata only; LICENSE lives in repo root) -->
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/Xml2Doc.md
+++ b/Xml2Doc.md
@@ -4,7 +4,8 @@ Xml2Doc converts C# compiler XML documentation into deterministic, linkable Mark
 
 ## Current status
 
-The current stable package line is `2.0.2`:
+The current stable package line is `2.0.3`. The next release is `2.1.0`, which adds
+programmatic rendering extension points while preserving the default `2.0.x` output contract:
 
 - `Xml2Doc.Core` provides parsing, rendering, output ownership, stale-file pruning, and line-ending normalization.
 - `Xml2Doc.Cli` provides repeatable command-line generation for development and CI.
@@ -13,8 +14,10 @@ The current stable package line is `2.0.2`:
 - Markdown uses LF on every platform by default.
 - Multiple projects can safely share an output directory when they have distinct manifest identities and disable their project-owned indexes.
 - Unified multi-project index aggregation is planned for `2.3.0`. Until then, maintain or generate the repository index separately.
-- Portable ownership manifests are implemented for the upcoming `2.0.3` release and migrate safe
-  2.0.x manifests when they are next saved.
+- Portable ownership manifests were added in `2.0.3` and migrate safe 2.0.x manifests when they
+  are next saved.
+- `2.1.0` makes anchors, aliases, templates, free-text linking, external symbol resolution, and
+  signature formatting replaceable through `RendererOptions`.
 
 ## Supported frameworks
 
@@ -36,7 +39,7 @@ The MSBuild package selects its task assembly automatically. Do not define a cus
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xml2Doc.MSBuild" Version="2.0.2" PrivateAssets="all">
+    <PackageReference Include="Xml2Doc.MSBuild" Version="2.1.0" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
@@ -54,13 +57,13 @@ Most Xml2Doc properties can be placed in either:
 
 Project properties override `Directory.Build.props`. Avoid defining a property in both unless the override is intentional.
 
-Keep string values such as the root namespace on one line. In 2.0.2, surrounding whitespace is preserved and can prevent prefix matching:
+Keep string values such as the root namespace on one line. Surrounding whitespace is preserved and can prevent prefix matching:
 
 ```xml
 <Xml2Doc_RootNamespaceToTrim>Rackspace.BAT.Core</Xml2Doc_RootNamespaceToTrim>
 ```
 
-The package currently assigns `Xml2Doc_Toc`, `Xml2Doc_NamespaceIndex`, and `Xml2Doc_BasenameOnly` unconditionally in its imported defaults. To enable them in 2.0.2, set them in the `.csproj` or `Directory.Build.targets`; a `Directory.Build.props` value may be overwritten.
+The package currently assigns `Xml2Doc_Toc`, `Xml2Doc_NamespaceIndex`, and `Xml2Doc_BasenameOnly` unconditionally in its imported defaults. To enable them, set them in the `.csproj` or `Directory.Build.targets`; a `Directory.Build.props` value may be overwritten.
 
 ## Complete MSBuild property reference
 
@@ -100,9 +103,9 @@ Reference XML contents are included in incremental fingerprinting.
 | `Xml2Doc_TrimRootNamespaceInFileNames` | `false` | `true`, `false` | Also removes the configured root namespace from filenames. |
 | `Xml2Doc_CodeBlockLanguage` | `csharp` | Fence language | Default fenced-code language. |
 | `Xml2Doc_AnchorAlgorithm` | `default` | `default`, `github`, `gfm`, `kramdown` | Controls heading/member anchors. Changing it can break published fragment links. |
-| `Xml2Doc_Toc` | `false` | `true`, `false` | Emits a member table of contents where supported. Set in `.csproj` or `Directory.Build.targets` in 2.0.2. |
-| `Xml2Doc_NamespaceIndex` | `false` | `true`, `false` | Emits namespace index output in per-type mode. Set in `.csproj` or `Directory.Build.targets` in 2.0.2. |
-| `Xml2Doc_BasenameOnly` | `false` | `true`, `false` | Drops namespace segments from filenames and increases collision risk. Set in `.csproj` or `Directory.Build.targets` in 2.0.2. |
+| `Xml2Doc_Toc` | `false` | `true`, `false` | Emits a member table of contents where supported. Set in `.csproj` or `Directory.Build.targets`. |
+| `Xml2Doc_NamespaceIndex` | `false` | `true`, `false` | Emits namespace index output in per-type mode. Set in `.csproj` or `Directory.Build.targets`. |
+| `Xml2Doc_BasenameOnly` | `false` | `true`, `false` | Drops namespace segments from filenames and increases collision risk. Set in `.csproj` or `Directory.Build.targets`. |
 | `Xml2Doc_LineEndings` | `lf` | `lf`, `crlf`, `native` | Normalizes generated Markdown at the output boundary. `lf` is deterministic across hosts. |
 
 Filename processing order is: filename-mode normalization, optional root-namespace trimming, then optional basename-only reduction.
@@ -139,7 +142,7 @@ history. Always ignore `.xml2doc/transactions`; it is local, best-effort staging
 | `Xml2Doc_DryRun` | `false` | `true`, `false` | Plans output without writing Markdown; a configured report can still be written. |
 | `Xml2Doc_Dump` | `false` | `true`, `false` | Logs evaluated paths and key generation inputs. |
 | `Xml2Doc_LogChosenTask` | `false` | `true`, `false` | Logs the selected task TFM and assembly path. |
-| `Xml2Doc_Diff` | `false` | Reserved | Has no effect in 2.0.2. |
+| `Xml2Doc_Diff` | `false` | Reserved | Has no effect in `2.1.0`. |
 
 Reports and transaction staging may be ignored:
 
@@ -211,7 +214,7 @@ Each participating `.csproj` still needs:
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="Xml2Doc.MSBuild" Version="2.0.2" PrivateAssets="all">
+  <PackageReference Include="Xml2Doc.MSBuild" Version="2.1.0" PrivateAssets="all">
     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
   </PackageReference>
 </ItemGroup>
@@ -227,6 +230,43 @@ Engine.Execution.BatExecutionService.md
 Do not enable `Xml2Doc_BasenameOnly` for a shared flat directory unless duplicate type names are impossible.
 
 Each invocation sees only its own compiler XML, so it cannot safely build an index containing the other projects. Keep `Xml2Doc_GenerateIndex=false` and maintain `docs/index.md` separately until multi-input aggregation is available.
+
+## Rendering extensibility in 2.1.0
+
+`Xml2Doc.Core` consumers can replace individual rendering services through `RendererOptions`.
+All extension points are optional; omitting them preserves the built-in output contract.
+
+| Option | Extension point | Default behavior |
+| --- | --- | --- |
+| `AliasProvider` | `IAliasProvider` | C# keyword aliases from `DefaultAliasProvider` |
+| `AnchorGenerator` | `IAnchorGenerator` | Selected built-in `AnchorAlgorithm` |
+| `TemplateRenderer` | `ITemplateRenderer` | Built-in layout, or file-based template/front matter when paths are configured |
+| `FrontMatter` | Metadata callback | No generated YAML front matter |
+| `AutoLinker` | `IAutoLinker` | `SimpleAutoLinker` when `AutoLink=true` |
+| `ExternalSymbolResolver` | `IExternalSymbolResolver` | Base-URL resolver when `ExternalDocs` is configured |
+| `SignatureRenderer` | `ISignatureRenderer` | `DefaultSignatureRenderer` |
+| `SignatureStyle` | Signature detail switches | Compatibility output without parameter names, constraints, or default values |
+
+Example:
+
+```csharp
+var options = new RendererOptions(
+    AnchorGenerator: new MyAnchorGenerator(),
+    AliasProvider: new MyAliasProvider(),
+    AutoLink: true,
+    AutoLinker: new MyAutoLinker(),
+    LinkPolicy: LinkPolicy.PreferExternalForUnknown,
+    ExternalSymbolResolver: new MyExternalSymbolResolver(),
+    SignatureStyle: new SignatureStyle(
+        IncludeParamNames: true,
+        IncludeConstraints: true,
+        IncludeDefaultValues: true),
+    SignatureRenderer: new MySignatureRenderer());
+```
+
+File-based templates, front matter, auto-linking, alias maps, and built-in anchor algorithms are
+available through the CLI. Custom service implementations and external link-policy selection
+require direct use of `Xml2Doc.Core`; broader CLI and MSBuild exposure is tracked for `2.2.0`.
 
 ## Conditional generation
 
@@ -276,7 +316,7 @@ Do not enable stale pruning in single-file mode; validation will fail.
 ## CLI quick start
 
 ```powershell
-dotnet tool install --global Xml2Doc.Cli --version 2.0.2
+dotnet tool install --global Xml2Doc.Cli --version 2.1.0
 
 xml2doc `
   --xml .\bin\Release\net9.0\MyLibrary.xml `
@@ -298,7 +338,7 @@ Use `--single` when `--out` names one combined file. Pruning is unavailable in s
 
 ### Full namespaces remain in filenames
 
-Embedded newlines or indentation can prevent an exact prefix match in 2.0.2. Inspect the evaluated values:
+Embedded newlines or indentation can prevent an exact prefix match. Inspect the evaluated values:
 
 ```powershell
 dotnet msbuild .\MyProject.csproj `
@@ -331,8 +371,8 @@ Temporarily enable:
 
 See [TODO.md](TODO.md) and [the ADR index](docs/adr/README.md). Notable planned work includes:
 
-- `2.0.3`: documentation and lifecycle correctness ([#68](https://github.com/mod-posh/xml2doc/issues/68), [#69](https://github.com/mod-posh/xml2doc/issues/69), and [#77](https://github.com/mod-posh/xml2doc/issues/77)).
-- `2.1.0`: rendering extensibility.
+- `2.0.3`: released documentation and lifecycle correctness.
+- `2.1.0`: completed rendering extensibility; release preparation is in progress.
 - `2.2.0`: diagnostics and pipeline improvements.
 - `2.3.0`: deterministic multi-project aggregation and a unified index.
 


### PR DESCRIPTION
## Summary

- update the root Xml2Doc guide for the upcoming 2.1.0 release
- document the rendering extension points and their default behavior
- update package and CLI examples to 2.1.0
- reconcile the changelog from 1.4.0 through 2.0.3
- add the unreleased 2.1.0 changelog entry

## Why

The root guide still described 2.0.2 and treated 2.0.3 as upcoming. The changelog still marked 1.4.0 as unreleased and omitted the 2.0.x release history. This aligns the documentation with the releases already published and the 2.1.0 release now being prepared.

## Impact

Consumers get current MSBuild and CLI examples, accurate lifecycle guidance, and a documented map of the new Core rendering extension points. The changelog now records the 2.0.1 packaging issue and its 2.0.2 correction, plus the lifecycle fixes released in 2.0.3.

## Validation

- `git diff --check`
- compared release entries with tags 1.4.0 through 2.0.3 and their generated release-note commits
- reviewed current Core, CLI, and MSBuild option wiring
- documentation-only change; local .NET tests were not run because the workspace does not have the .NET SDK

## Follow-up

`Directory.Build.props` still reports version 2.0.3 and should be bumped to 2.1.0 as part of release preparation.