### PR TITLE
Finalize documentation for 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.1.0] - Unreleased
+## [2.1.0](https://github.com/mod-posh/Xml2Doc/releases/tag/2.1.0) - 2026-08-16
 
 ### Added
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,12 @@
 # Xml2Doc Roadmap
 
-This roadmap groups the current open issues into focused release milestones. The current stable release is `2.0.3`. Milestone versions are proposed and may be adjusted before release, but the dependency order should remain stable.
+This roadmap groups the current open issues into focused release milestones. The current stable release is `2.1.0`. Milestone versions are proposed and may be adjusted before release, but the dependency order should remain stable.
 
 ## Release sequence
 
 1. `2.0.3` — Documentation and Lifecycle Correctness (released)
-2. `2.1.0` — Rendering Extensibility (current)
-3. `2.2.0` — Diagnostics and Pipeline
+2. `2.1.0` — Rendering Extensibility (released)
+3. `2.2.0` — Diagnostics and Pipeline (current)
 4. `2.3.0` — Multi-project Aggregation
 
 ## 2.0.3 — Documentation and Lifecycle Correctness

--- a/Xml2Doc.md
+++ b/Xml2Doc.md
@@ -4,8 +4,8 @@ Xml2Doc converts C# compiler XML documentation into deterministic, linkable Mark
 
 ## Current status
 
-The current stable package line is `2.0.3`. The next release is `2.1.0`, which adds
-programmatic rendering extension points while preserving the default `2.0.x` output contract:
+The current stable package line is `2.1.0`. This release adds programmatic rendering extension
+points while preserving the default `2.0.x` output contract:
 
 - `Xml2Doc.Core` provides parsing, rendering, output ownership, stale-file pruning, and line-ending normalization.
 - `Xml2Doc.Cli` provides repeatable command-line generation for development and CI.
@@ -372,8 +372,8 @@ Temporarily enable:
 See [TODO.md](TODO.md) and [the ADR index](docs/adr/README.md). Notable planned work includes:
 
 - `2.0.3`: released documentation and lifecycle correctness.
-- `2.1.0`: completed rendering extensibility; release preparation is in progress.
-- `2.2.0`: diagnostics and pipeline improvements.
+- `2.1.0`: released rendering extensibility.
+- `2.2.0`: current diagnostics and pipeline milestone.
 - `2.3.0`: deterministic multi-project aggregation and a unified index.
 
 Report bugs and feature requests in the [GitHub issue tracker](https://github.com/mod-posh/xml2doc/issues).


### PR DESCRIPTION
## Summary

- declare 2.1.0 as the current stable package line in `Xml2Doc.md`
- date and link the 2.1.0 changelog entry
- mark 2.1.0 released and advance 2.2.0 to the current roadmap milestone

## Why

The milestone-close workflow regenerates `README.md` from `Xml2Doc.md` and regenerates `RELEASE.md`, but it does not alter the release-state language in the source guide, changelog, or roadmap. Without this change, the generated README would still identify 2.0.3 as current after the 2.1.0 release.

## Impact

This prepares the source documentation for milestone #12 closure. The expected pre-release drift in `README.md` and `RELEASE.md` remains untouched so the milestone workflow can regenerate those artifacts.

## Validation

- `git diff --check`
- confirmed `Directory.Build.props` already uses `VersionPrefix` 2.1.0
- confirmed Merge Test, CLI Integration, MSBuild Integration, and MSBuild Package Integration passed for the version-bump commit
- documentation-only change