### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/msbuild-integration.yml
+++ b/.github/workflows/msbuild-integration.yml
@@ -15,6 +15,9 @@ on:
       - "global.json"
       - "Directory.Build.props"
 
+permissions:
+  contents: read
+
 jobs:
   msbuild_integration:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/xml2doc/security/code-scanning/11](https://github.com/mod-posh/xml2doc/security/code-scanning/11)

Add an explicit `permissions` block to the workflow YAML so the `GITHUB_TOKEN` is restricted to only what this workflow needs.  
Best fix here (without changing behavior): define permissions at the workflow root so it applies to all jobs in this file (currently one job). Use:

- `contents: read` (needed by `actions/checkout`)
- optionally `packages: read` if package reads might occur; not required by the shown steps

Given the current snippet, the minimal and safest explicit setting is `contents: read`.

**File to change:** `.github/workflows/msbuild-integration.yml`  
**Region:** near the top-level keys, immediately after `on:` block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
