### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ on:
       - "RELEASE.md"
       - "Xml2Doc.md"
 
+permissions:
+  contents: read
+
 jobs:
   run_tests:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/xml2doc/security/code-scanning/9](https://github.com/mod-posh/xml2doc/security/code-scanning/9)

Add an explicit `permissions` block to the workflow file `.github/workflows/test.yml` at the top level (root), just after the `on:` triggers (or before `jobs:`). Since this is a CI test workflow that checks out code, builds, tests, and uploads artifacts, the minimal and appropriate permission is:

- `contents: read`

This preserves current functionality while enforcing least privilege for all jobs in the workflow. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
