### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -16,6 +16,9 @@ on:
       - "global.json"
       - "Directory.Build.props"
 
+permissions:
+  contents: read
+
 jobs:
   cli_integration:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mod-posh/xml2doc/security/code-scanning/6](https://github.com/mod-posh/xml2doc/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: add `permissions: { contents: read }` at the workflow root (after `on` section and before `jobs`). This applies to all jobs unless overridden and matches the minimal permission required for checkout/read operations, without changing intended functionality.

File/region to change:
- `.github/workflows/cli-integration.yml`
- Insert a workflow-level `permissions` block between lines 18 and 19 (between triggers and `jobs`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
